### PR TITLE
 Fix Grafana PV can't be mounted (Patch)

### DIFF
--- a/charts/rancher-monitoring/v0.0.1/charts/grafana/templates/dashboards-configmap.yaml
+++ b/charts/rancher-monitoring/v0.0.1/charts/grafana/templates/dashboards-configmap.yaml
@@ -17,7 +17,7 @@ data:
       "access": "proxy",
       "basicAuth": false,
       "editable": false,
-      "isDefault:": true,
+      "isDefault": true,
       "name": "Rancher-Monitoring",
       "type": "prometheus",
       "url": "{{ .Values.prometheusDatasourceURL }}"

--- a/charts/rancher-monitoring/v0.0.1/charts/grafana/templates/dashboards-configmap.yaml
+++ b/charts/rancher-monitoring/v0.0.1/charts/grafana/templates/dashboards-configmap.yaml
@@ -17,7 +17,7 @@ data:
       "access": "proxy",
       "basicAuth": false,
       "editable": false,
-      "isDefault": true,
+      "isDefault:": true,
       "name": "Rancher-Monitoring",
       "type": "prometheus",
       "url": "{{ .Values.prometheusDatasourceURL }}"

--- a/charts/rancher-monitoring/v0.0.1/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.1/charts/grafana/templates/deployment.yaml
@@ -61,8 +61,6 @@ spec:
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 8 }}
 {{- end }}
-        securityContext:
-          fsGroup: 472
         volumeMounts:
         - name: grafana-storage
           mountPath: /var/lib/grafana

--- a/charts/rancher-monitoring/v0.0.1/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.1/charts/grafana/templates/deployment.yaml
@@ -143,6 +143,8 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
+      securityContext:
+        fsGroup: 472
       volumes:
       - name: grafana-static-hooks
         configMap:


### PR DESCRIPTION
**Problem:**
Grafana still can't mount PV correctly in Cloud, because there are 2
`securityContext` and `fsGroup` only work on Pod spec.

**Solution:**
Change the `securityContext` to Pod spec.

**Issue:**
rancher/rancher#16953