### PR TITLE
Schedule node-exporter to controlplane and etcd roles

### DIFF
--- a/charts/rancher-monitoring/v0.0.1/charts/exporter-node/templates/daemonset.yaml
+++ b/charts/rancher-monitoring/v0.0.1/charts/exporter-node/templates/daemonset.yaml
@@ -20,14 +20,6 @@ spec:
         chart: {{ template "app.version" . }}
         release: {{ .Release.Name }}
     spec:
-      tolerations:
-      - operator: "Exists"
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - key: "node-role.kubernetes.io/etcd"
-        operator: "Exists"
-      - key: "node-role.kubernetes.io/controlplane"
-        operator: "Exists"
       containers:
         - name: exporter-node
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/rancher-monitoring/v0.0.1/charts/exporter-node/values.yaml
+++ b/charts/rancher-monitoring/v0.0.1/charts/exporter-node/values.yaml
@@ -55,8 +55,7 @@ container:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations:
-- effect: NoSchedule
-  operator: Exists
+- operator: Exists
 
 ## Node Selector to constrain pods to run on particular nodes
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
**Problem:**
`node-exporter` component isn't scheduling to controlplane and etcd role
nodes

**Solution:**
Modify `taints`

**Issue:**
https://github.com/rancher/rancher/issues/17030