### PR TITLE
Add ability to use private image registry when deploying logging tools

### DIFF
--- a/charts/rancher-logging/0.0.1/charts/fluentd-tester/templates/deployment.yaml
+++ b/charts/rancher-logging/0.0.1/charts/fluentd-tester/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: {{ template "fluentd-tester.fullname" . }}
       containers:
       - name: "dry-run"
-        image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.command }}
         command: {{ .Values.command }}

--- a/charts/rancher-logging/0.0.1/charts/fluentd/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.0.1/charts/fluentd/templates/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: {{ template "fluentd.fullname" . }}
       containers:
       - name: {{ template "fluentd.fullname" . }}
-        image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image:  {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.command }}
         command: {{ .Values.command }}
@@ -123,7 +123,7 @@ spec:
               fi;
 {{- end }}
       - name: {{ template "fluentd.fullname" . }}-{{ .Values.configmapReload.name }}
-        image: "{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}"
+        image: {{ template "system_default_registry" . }}{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}
         imagePullPolicy: "{{ .Values.configmapReload.image.pullPolicy }}"
         args:
           - --volume-dir=/fluentd/etc/config/custom

--- a/charts/rancher-logging/0.0.1/charts/log-aggregator/templates/log-aggregator.yaml
+++ b/charts/rancher-logging/0.0.1/charts/log-aggregator/templates/log-aggregator.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: {{ template "log-aggregator.fullname" . }}
       containers:
       - name: log-aggregator
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         securityContext:
           privileged: true

--- a/charts/rancher-logging/0.0.1/templates/_helpers.tpl
+++ b/charts/rancher-logging/0.0.1/templates/_helpers.tpl
@@ -33,3 +33,12 @@
 {{- "rbac.authorization.k8s.io/v1alpha1" -}}
 {{- end -}}
 {{- end -}}
+
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-logging/0.0.1/values.yaml
+++ b/charts/rancher-logging/0.0.1/values.yaml
@@ -5,3 +5,5 @@ fluentd-tester:
 log-aggregator:
   enabled: false
   flexVolumeDir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+global:
+  systemDefaultRegistry: ""


### PR DESCRIPTION
problem:
After we refactored the logging, we can not deploy logging tools in an
air gap environment.

Solution:
Add the ability to use the private image registry when deploying logging
tools

Issue:
https://github.com/rancher/rancher/issues/17568