### PR TITLE
Add ability to use private image registry when deploying monitoring tools

### DIFF
--- a/charts/rancher-monitoring/v0.0.2/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/alertmanager/templates/alertmanager.yaml
@@ -24,7 +24,7 @@ spec:
       chart: {{ template "app.version" . }}
       release: {{ .Release.Name }}
 {{- end }}
-  baseImage: "{{ .Values.image.repository }}"
+  baseImage: {{ template "system_default_registry" . }}{{ .Values.image.repository }}
 {{- if .Values.externalUrl }}
   externalUrl: "{{ .Values.externalUrl }}"
 {{- end }}

--- a/charts/rancher-monitoring/v0.0.2/charts/alertmanager/templates/nginx-deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/alertmanager/templates/nginx-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       containers:
       - name: alertmanager-proxy
-        image: {{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
         args:
         - nginx
         - -g

--- a/charts/rancher-monitoring/v0.0.2/charts/exporter-kube-state/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/exporter-kube-state/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kube-state
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:
         - name: http
           containerPort: 8080

--- a/charts/rancher-monitoring/v0.0.2/charts/exporter-node/templates/daemonset.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/exporter-node/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: exporter-node
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         args:
         - --web.listen-address=$(POD_IP):{{ .Values.ports.metrics.port }}
         - --path.procfs=/host/proc

--- a/charts/rancher-monitoring/v0.0.2/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/grafana/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       initContainers:
       - name: grafana-init-plugin-json-copy
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         {{- if and .Values.resources .Values.resources.inits }}
         resources:
 {{ toYaml .Values.resources.inits | indent 10 }}
@@ -35,7 +35,7 @@ spec:
         - name: grafana-static-contents
           mountPath: /host
       - name: grafana-init-plugin-json-modify
-        image: {{ .Values.image.tool.repository }}:{{ .Values.image.tool.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.tool.repository }}:{{ .Values.image.tool.tag }}
         command:
         - /usr/bin/modify-datasource-plugin-json.sh
         {{- if and .Values.resources .Values.resources.inits }}
@@ -50,7 +50,7 @@ spec:
           mountPath: /host
       containers:
       - name: grafana
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         env:
         - name: GF_AUTH_BASIC_ENABLED
           value: "true"
@@ -90,7 +90,7 @@ spec:
 {{ toYaml .Values.resources.core | indent 10 }}
         {{- end }}
       - name: grafana-proxy
-        image: {{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
         args:
         - nginx
         - -g

--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/nginx-deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/nginx-deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
       - name: nginx-init-auth-add
-        image: {{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
         command:
         - /usr/bin/replace-config-by-auth.sh
         volumeMounts:
@@ -43,7 +43,7 @@ spec:
         {{- end }}
       containers:
       - name: prometheus-proxy
-        image: {{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
         args:
         - nginx
         - -g

--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/prometheus.yaml
@@ -29,7 +29,7 @@ spec:
     env:
 {{ toYaml .Values.auth.env | indent 6 }}
     {{- end }}
-    image: {{ .Values.image.auth.repository }}:{{ .Values.image.auth.tag }}
+    image: {{ template "system_default_registry" . }}{{ .Values.image.auth.repository }}:{{ .Values.image.auth.tag }}
     ports:
     - containerPort: 9090
       name: web
@@ -88,7 +88,7 @@ spec:
         name: alertmanager-operated
         port: http
 {{- end }}
-  baseImage: "{{ .Values.image.repository }}"
+  baseImage: {{ template "system_default_registry" . }}{{ .Values.image.repository }}
 {{- if .Values.externalLabels }}
   externalLabels:
 {{ toYaml .Values.externalLabels | indent 4}}

--- a/charts/rancher-monitoring/v0.0.2/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/v0.0.2/templates/_helpers.tpl
@@ -117,3 +117,12 @@
 {{- "rbac.authorization.k8s.io/v1alpha1" -}}
 {{- end -}}
 {{- end -}}
+
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-monitoring/v0.0.2/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.2/templates/deployment.yaml
@@ -24,13 +24,13 @@ spec:
     spec:
       containers:
         - name: prometheus-operator
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           args:
             - --kubelet-service={{ .Release.Namespace }}/expose-kubelets-metrics
             - --log-format={{ .Values.logFormat }}
             - --log-level={{ .Values.logLevel }}
-            - --prometheus-config-reloader={{ .Values.image.prometheusConfigReloader.repository }}:{{ .Values.image.prometheusConfigReloader.tag }}
-            - --config-reloader-image={{ .Values.image.configmapReload.repository }}:{{ .Values.image.configmapReload.tag }}
+            - --prometheus-config-reloader={{ template "system_default_registry" . }}{{ .Values.image.prometheusConfigReloader.repository }}:{{ .Values.image.prometheusConfigReloader.tag }}
+            - --config-reloader-image={{ template "system_default_registry" . }}{{ .Values.image.configmapReload.repository }}:{{ .Values.image.configmapReload.tag }}
             - --labels={{ .Values.apiGroup }}=true
             - --crd-apigroup={{ template "operator_api_group" . }}
             - --manage-crds={{ .Values.manageCRDs }}

--- a/charts/rancher-monitoring/v0.0.2/values.yaml
+++ b/charts/rancher-monitoring/v0.0.2/values.yaml
@@ -411,3 +411,6 @@ prometheus:
     runAsUser: 1000
     runAsNonRoot: true
     fsGroup: 2000
+
+global:
+  systemDefaultRegistry: ""


### PR DESCRIPTION
problem:
We can not deploy monitoring tools in an air gap environment.

Solution:
Add the ability to use the private image registry when deploying
monitoring tools

Issue:
https://github.com/rancher/rancher/issues/17842

Test steps:
1. Set the `system-default-registry` to a private registry via the Settings menu.
2. Launch the monitoring.
3. Check if the rancher-monitoring app pulls the image from the set private registry.