### PR TITLE
 Support choosing Prometheus sync mode between federate and remote

### DIFF
--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/additionals/w-scrape_federate.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/additionals/w-scrape_federate.yaml
@@ -1,0 +1,13 @@
+{{- if and (eq .Values.level "project") (eq .Values.sync.mode "federate") }}
+- job_name: 'federate'
+  scrape_interval: 15s
+  honor_labels: true
+  metrics_path: {{ .Values.sync.path }}
+  params:
+    'match[]':
+      - '{__name__=~".+"}'
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  static_configs:
+  - targets:
+    - {{ trimPrefix "https://" (trimPrefix "http://" .Values.sync.target) }}
+{{- end }}

--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/_helpers.tpl
@@ -5,17 +5,23 @@
 {{- $yamls := dict -}}
 {{- if eq .Values.level "cluster" -}}
   {{- range $path, $bytes := .Files.Glob "additionals/c-scrape_*.yaml" -}}
-    {{- $_ := set $yamls (tpl ($bytes | toString) $root) "" -}}
+    {{- $tpl := tpl ($bytes | toString) $root }}
+    {{- if $tpl }}
+    {{- $_ := set $yamls $tpl "" -}}
+    {{- end }}
   {{- end -}}
 {{- end -}}
 {{- range $path, $bytes := .Files.Glob "additionals/w-scrape_*.yaml" -}}
-  {{- $_ := set $yamls (tpl ($bytes | toString) $root) "" -}}
+  {{- $tpl := tpl ($bytes | toString) $root }}
+  {{- if $tpl }}
+  {{- $_ := set $yamls $tpl "" -}}
+  {{- end }}
 {{- end -}}
 {{- if .Values.additionalScrapeConfigs -}}
   {{- $_ := set $yamls (.Values.additionalScrapeConfigs | toYaml) "" -}}
 {{- end -}}
 {{- if $yamls -}}
-  {{- keys $yamls | join "\\n" | b64enc | quote -}}
+  {{- keys $yamls | join "\n" | b64enc | quote -}}
 {{- end -}}
 {{- end -}}
 
@@ -25,17 +31,23 @@
 {{- $yamls := dict -}}
 {{- if eq .Values.level "cluster" -}}
   {{- range $path, $bytes := .Files.Glob "additionals/c-altermanager_*.yaml" -}}
-    {{- $_ := set $yamls (tpl ($bytes | toString) $root) "" -}}
+    {{- $tpl := tpl ($bytes | toString) $root }}
+    {{- if $tpl }}
+    {{- $_ := set $yamls $tpl "" -}}
+    {{- end }}
   {{- end -}}
 {{- end -}}
 {{- range $path, $bytes := .Files.Glob "additionals/w-altermanager_*.yaml" -}}
-  {{- $_ := set $yamls (tpl ($bytes | toString) $root) "" -}}
+  {{- $tpl := tpl ($bytes | toString) $root }}
+  {{- if $tpl }}
+  {{- $_ := set $yamls $tpl "" -}}
+  {{- end }}
 {{- end -}}
 {{- if .Values.additionalAlertManagerConfigs -}}
   {{- $_ := set $yamls (.Values.additionalAlertManagerConfigs | toYaml) "" -}}
 {{- end -}}
 {{- if $yamls -}}
-  {{- keys $yamls | join "\\n" | b64enc | quote -}}
+  {{- keys $yamls | join "\n" | b64enc | quote -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/prometheus.yaml
@@ -119,13 +119,10 @@ spec:
   serviceMonitorSelector:
 {{ toYaml .Values.serviceMonitorSelector | indent 4 }}
 {{- end }}
-{{- if .Values.remoteRead }}
+{{- if and (eq .Values.level "project") (eq .Values.sync.mode "remote") }}
   remoteRead:
-{{ toYaml .Values.remoteRead | indent 4 }}
-{{- end }}
-{{- if .Values.remoteWrite }}
-  remoteWrite:
-{{ toYaml .Values.remoteWrite | indent 4 }}
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    url: {{ printf "%s%s" .Values.sync.target .Values.sync.path }}
 {{- end }}
 {{- if .Values.ruleNamespaceSelector }}
   ruleNamespaceSelector:

--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/rbac.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/rbac.yaml
@@ -86,7 +86,7 @@ subjects:
     name: {{ default (include "app.fullname" .) .Values.serviceAccountNameOverride }}
     namespace: {{ .Release.Namespace }}
 
-{{- if ne .Values.level "cluster" }}
+{{- if eq .Values.level "project" }}
 ---
 apiVersion: {{ template "rbac_api_version" . }}
 kind: Role

--- a/charts/rancher-monitoring/v0.0.2/values.yaml
+++ b/charts/rancher-monitoring/v0.0.2/values.yaml
@@ -368,6 +368,10 @@ prometheus:
     runAsUser: 1000
     runAsNonRoot: true
     fsGroup: 2000
+  sync:
+    mode: "remote"
+    path: "/api/v1/read"
+    target: ""
 
 global:
   systemDefaultRegistry: ""


### PR DESCRIPTION
Support choosing Prometheus sync mode between federate and remote  …
**Problem:**
- Remote reader mode only allow `project-level` Prometheus to share the
metrics from `cluster-level` Prometheus
- Remote reader mode cannot save the namespace-related metrics from
`cluster-level` Prometheus

**Solution:**
- Add `prometheus.sync.mode` to choose
- Add a "federate" scrape job when deploying federation mode

**Issue:**
rancher/rancher#17390
