### PR TITLE
Should consist label in service monitor and logging charts

### DIFF
--- a/charts/rancher-monitoring/v0.0.1/charts/exporter-fluentd/templates/servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.0.1/charts/exporter-fluentd/templates/servicemonitor.yaml
@@ -15,11 +15,11 @@ spec:
   jobLabel: fluentd
   selector:
     matchLabels:
-      k8s-app: fluentd
+      app: fluentd
   namespaceSelector:
     matchNames:
       - cattle-logging
   endpoints:
-  - port: metrics
+  - port: metric
     interval: 15s
     honorLabels: true


### PR DESCRIPTION
Problem:
enable logging and moinitoring but can't see fluentd metric

Solution:
consist label and endpoint name

Issue:
https://github.com/rancher/rancher/issues/18327