### PR TITLE
Upgrade Monitoring images version

### DIFF
--- a/charts/rancher-monitoring/v0.0.2/values.yaml
+++ b/charts/rancher-monitoring/v0.0.2/values.yaml
@@ -4,10 +4,10 @@ enabledRBAC: true
 apiGroup: "monitoring.coreos.com"
 image:
   repository: rancher/coreos-prometheus-operator
-  tag: v0.26.0
+  tag: v0.29.0
   prometheusConfigReloader:
     repository: rancher/coreos-prometheus-config-reloader
-    tag: v0.26.0
+    tag: v0.29.0
   configmapReload:
     repository: rancher/coreos-configmap-reload
     tag: v0.0.1
@@ -150,7 +150,7 @@ exporter-node:
   enabled: false
   apiGroup: "monitoring.coreos.com"
   image:
-    repository: rancher/node-exporter
+    repository: rancher/prom-node-exporter
     tag: v0.17.0
   nodeSelectors: []
   resources:
@@ -175,7 +175,7 @@ exporter-kube-state:
   apiGroup: "monitoring.coreos.com"
   image:
     repository: rancher/coreos-kube-state-metrics
-    tag: v1.4.0
+    tag: v1.5.0
   nodeSelectors: []
   resources:
     limits:
@@ -194,7 +194,7 @@ alertmanager:
   apiGroup: "monitoring.coreos.com"
   image:
     repository: rancher/prom-alertmanager
-    tag: v0.15.2
+    tag: v0.16.1
   nodeSelectors: []
   resources:
     core:
@@ -237,8 +237,8 @@ grafana:
   level: cluster
   apiGroup: "monitoring.coreos.com"
   image:
-    repository: rancher/grafana
-    tag: 5.3.0
+    repository: rancher/grafana-grafana
+    tag: 5.4.3
     tool:
       repository: rancher/prometheus-auth
       tag: v0.2.0
@@ -294,8 +294,8 @@ prometheus:
           fieldPath: status.podIP
   apiGroup: "monitoring.coreos.com"
   image:
-    repository: rancher/prometheus
-    tag: v2.5.0
+    repository: rancher/prom-prometheus
+    tag: v2.7.1
     auth:
       repository: rancher/prometheus-auth
       tag: v0.2.0


### PR DESCRIPTION
**Problem:**
Cannot start "rules-configmap-reloader" container with 10Mi limit resource

**Solution:**
Update images:

| docker.io/quay.io official | rancher alias |
| --- | --- |
| quay.io/coreos/prometheus-operator:v0.29.0 | rancher/coreos-prometheus-operator:v0.29.0 |
| quay.io/coreos/prometheus-config-reloader:v0.29.0 | rancher/coreos-prometheus-config-reloader:v0.29.0 |
| prom/node-exporter:v0.17.0 | rancher/prom-node-exporter:v0.17.0 |
| quay.io/coreos/kube-state-metrics:v1.5.0 | rancher/coreos-kube-state-metrics:v1.5.0 |
| prom/alertmanager:v0.16.1 | rancher/prom-alertmanager:v0.16.1 |
| grafana/grafana:5.4.3 | rancher/grafana-grafana:5.4.3 |
| prom/prometheus:v2.7.1 | rancher/prom-prometheus:v2.7.1 |

**Issue:**
- https://github.com/rancher/rancher/issues/17997
- https://github.com/rancher/rancher/issues/18353