### PR TITLE
upgrade fluentd image version

### DIFF
--- a/charts/rancher-logging/0.0.1/charts/fluentd/values.yaml
+++ b/charts/rancher-logging/0.0.1/charts/fluentd/values.yaml
@@ -2,7 +2,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.12
+  tag: v0.1.13
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
problem:
before fluentd 1.3.1 version can't support add client cert for fluentd output

Solution:
upgrade fluentd to 1.3.3, but the related kafka gem also upgrade small
version, tested fluentd and kafka after upgrade version

Issue:
https://github.com/rancher/rancher/issues/18396