### PR TITLE
Use updated rancher image of external-dns with version 0.5.11

### DIFF
--- a/charts/rancher-external-dns/v0.0.1/Chart.yaml
+++ b/charts/rancher-external-dns/v0.0.1/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   for Kubernetes Ingresses and Services
 name: rancher-external-dns
 version: 0.0.1 
-appVersion: 0.5.10
+appVersion: 0.5.11
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
   - https://github.com/kubernetes-incubator/external-dns

--- a/charts/rancher-external-dns/v0.0.1/values.yaml
+++ b/charts/rancher-external-dns/v0.0.1/values.yaml
@@ -1,7 +1,7 @@
 ## Details about the image to be pulled.
 image:
   name: rancher/kubernetes-external-dns
-  tag: v0.5.10
+  tag: v0.5.11
   pullSecrets: []
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Fix for https://github.com/rancher/rancher/issues/18454

There is a introduced in the kubernetes-incubator/external-dns v0.5.10 version that we use to launch external-dns. Refer the issue here:
[kubernetes-incubator/external-dns#883](https://github.com/kubernetes-incubator/external-dns/issues/883)

As mentioned in this issue, trying out with version v0.5.11 resolves this problem. 

This PR updates the chart version to use the update image.