### PR TITLE
Start prometheus proxy nginx in process 1

### DIFF
--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/nginx-configmap.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/nginx-configmap.yaml
@@ -15,14 +15,14 @@ data:
     srcpath="/nginx/nginx-conf.tmpl"
     dstpath="/var/run/nginx.conf"
 
-    if ![ -f $srcpath ]; then
+    if ! [ -f $srcpath ]; then
       exit 1
     fi
 
     token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
     sed "s/REPLACE_PARAM_AUTHORIZATION/Bearer ${token}/g" $srcpath | sed "s/REPLACE_PARAM_IP/${POD_IP}/g" > $dstpath
     
-    nginx -g "daemon off;" -c /var/run/nginx.conf
+    exec nginx -g "daemon off;" -c /var/run/nginx.conf
 
   nginx-conf.tmpl: |-
     user                  nginx;


### PR DESCRIPTION
**Problem:**
When we start nginx in our start-up script, the nginx process would
become the child process of start-up script process and not process 1.
In this case, the kill signal from kubelet/docker will be sent to
start-up script instead of nginx so the nginx process won't stop after
kill.

**Solution:**
Change the proxy command and let nginx start at process 1.

Related issue: https://github.com/rancher/rancher/issues/18508