### PR TITLE
Project monitoring SA should mount the specific cluster role

### DIFF
--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/rbac.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/rbac.yaml
@@ -126,30 +126,27 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- $rbacAPIVersion := include "rbac_api_version" .  }}
+{{- $projectId :=  index (index .Values.serviceMonitorNamespaceSelector.matchExpressions 0).values 0 }}
 {{- $appServiceAccountName := default (include "app.fullname" .) .Values.serviceAccountNameOverride }}
 {{- $appName := include "app.name" . }}
 {{- $appVersion := include "app.version" . }}
-{{- $root := . -}}
-{{ range .Values.additionalBindingClusterRoles }}
 ---
-apiVersion: {{ $rbacAPIVersion }}
+apiVersion: {{ template "rbac_api_version" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:
     app: {{ $appName }}
     chart: {{ $appVersion }}
-    heritage: {{ $root.Release.Service }}
-    release: {{ $root.Release.Name }}
-  name: {{ . }}-additional-binding
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ $projectId }}-namespaces-readonly-additional-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ . }}
+  name: {{ $projectId }}-namespaces-readonly
 subjects:
   - kind: ServiceAccount
     name: {{ $appServiceAccountName }}
-    namespace: {{ $root.Release.Namespace }}
+    namespace: {{ .Release.Namespace }}
 
-{{ end }}
 {{- end }}

--- a/charts/rancher-monitoring/v0.0.2/values.yaml
+++ b/charts/rancher-monitoring/v0.0.2/values.yaml
@@ -336,7 +336,6 @@ prometheus:
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector:
     matchExpressions: []
-  addtionalBindingClusterRoles: []
   securityContext:
     runAsUser: 1000
     runAsNonRoot: true


### PR DESCRIPTION
**Problem:**
Users can change the answers of project monitoring apps to get more privileges
in the cluster. It should not be allowed.

**Solution:**
The project monitoring app should only be able to mount to the specific role
`<Project-Id>-namespaces-readonly-additional-binding`.