### PR TITLE
[WIP] Add option to use release name of prometheus pvc

### DIFF
--- a/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.2/charts/prometheus/templates/prometheus.yaml
@@ -151,6 +151,10 @@ spec:
 {{- if or .Values.storageSpec .Values.persistence.enabled }}
   storage:
     volumeClaimTemplate:
+      {{- if .Values.persistence.useReleaseName }}
+      metadata:
+        name: {{ .Release.Name }}
+      {{- end }}
       spec:
 {{- if .Values.storageSpec }}
 {{ toYaml .Values.storageSpec | indent 8 }}

--- a/charts/rancher-monitoring/v0.0.2/values.yaml
+++ b/charts/rancher-monitoring/v0.0.2/values.yaml
@@ -320,6 +320,7 @@ prometheus:
         memory: 100Mi
         cpu: 100m
   persistence:
+    useReleaseName: false
     enabled: false
     storageClass: ""
     accessMode: "ReadWriteOnce"


### PR DESCRIPTION
**Problem:**
for some storage providers like OpenEBS and ceph, the default pvc name is exceeding the PVC name restriction of 63 chars.
https://github.com/rancher/rancher/issues/19410

**Solution:**
Add `prometheus.persistent.useReleaseName` option to overwrite the default pvc name using releaseName, e.g origin
`prometheus-cluster-monitoring-db-prometheus-cluster-monitoring-0` will be updated to `cluster-monitoring-prometheus-cluster-monitoring-0`.