### PR TITLE
Project monitoring fix

### DIFF
--- a/charts/rancher-monitoring/v0.0.3/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.3/charts/grafana/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
         {{- end }}
         {{- end }}
     {{- if .Values.enabledRBAC }}
-      serviceAccountName: {{ default (include "app.fullname" .) .Values.serviceAccountName }}
+      serviceAccountName: {{ default (default (include "app.fullname" .) .Values.serviceAccountName) .Values.serviceAccountNameOverride }}
     {{- end }}
     {{- if .Values.tolerations }}
       tolerations:

--- a/charts/rancher-monitoring/v0.0.3/charts/prometheus/additionals/w-altermanager_project.yaml
+++ b/charts/rancher-monitoring/v0.0.3/charts/prometheus/additionals/w-altermanager_project.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.level "project" }}
+- static_configs: 
+  - targets: 
+    - {{ .Values.project.alertManagerTarget }}
+    labels: 
+      level: {{ .Values.level }}
+      project_id: {{ .Values.global.projectName }}
+      cluster_id: {{ .Values.global.clusterName }}
+      cluster_name: {{ .Values.project.clusterDisplayName }}
+      project_name: {{ .Values.project.projectDisplayName }}
+{{- end }}

--- a/charts/rancher-monitoring/v0.0.3/charts/prometheus/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/v0.0.3/charts/prometheus/templates/_helpers.tpl
@@ -56,3 +56,52 @@
 {{- $name := include "app.name" . -}}
 {{- printf "%s-auth-%s" $name .Release.Name -}}
 {{- end -}}
+
+{{- define "namespace.selector" -}}
+{{- if and .selector .selector.matchLabels -}}
+matchLabels:
+{{ toYaml .selector.matchLabels | indent 2 }}
+{{- end }}
+matchExpressions:
+{{- if .projectName }}
+- key: "field.cattle.io/projectId"
+  operator: "In"
+  values: [ "{{ .projectName }}" ]
+{{- end }}
+{{- if and .selector .selector.matchExpressions }}
+{{ toYaml .selector.matchExpressions }}
+{{- end -}}
+{{- end -}}
+
+{{- define "serviceMonitor.namespace.selector" -}}
+{{- $rootContext := dict -}}
+{{- $_ := set $rootContext "projectName" .Values.global.projectName -}}
+{{- $_ := set $rootContext "selector" .Values.serviceMonitorNamespaceSelector -}}
+serviceMonitorNamespaceSelector:
+{{ include "namespace.selector" $rootContext | indent 2 }}
+{{- end -}}
+
+{{- define "rule.namespace.selector" -}}
+{{- $rootContext := dict -}}
+{{- $_ := set $rootContext "projectName" .Values.global.projectName -}}
+{{- $_ := set $rootContext "selector" .Values.ruleNamespaceSelector -}}
+ruleNamespaceSelector:
+{{ include "namespace.selector" $rootContext | indent 2 }}
+{{- end -}}
+
+{{- define "rule.selector" -}}
+ruleSelector:
+{{- if and .Values.ruleSelector .Values.ruleSelector.matchLabels }}
+  matchLabels:
+{{ toYaml .Values.ruleSelector.matchLabels | indent 4}}
+{{- end }}
+  matchExpressions:
+{{- if eq .Values.level "project" }}
+  - key: "source"
+    operator: "In"
+    values: [ "rancher-alert" ]
+{{- end }}
+{{- if and .Values.ruleSelector .Values.ruleSelector.matchExpressions }}
+{{ toYaml .Values.ruleSelector.matchExpressions | indent 2}}
+{{- end }}
+{{- end }}

--- a/charts/rancher-monitoring/v0.0.3/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.3/charts/prometheus/templates/prometheus.yaml
@@ -91,14 +91,19 @@ spec:
 {{- else if not (include "additional-alertmanager-configs.yaml" .) }}
   alerting:
     alertmanagers:
-      - namespace: {{ .Release.Namespace }}
+      - namespace: {{ .Values.cluster.alertManagerNamespace }}
         name: alertmanager-operated
         port: http
 {{- end }}
   baseImage: {{ template "system_default_registry" . }}{{ .Values.image.repository }}
-{{- if .Values.externalLabels }}
+{{- if or (.Values.externalLabels) (eq .Values.level "project") }}
   externalLabels:
-{{ toYaml .Values.externalLabels | indent 4}}
+{{- if and (eq .Values.level "project") }}
+    prometheus_from: {{ .Values.global.clusterName }}
+{{- end }}
+{{- range $key, $value := .Values.externalLabels}}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
   nodeSelector:
     beta.kubernetes.io/os: linux
@@ -130,11 +135,8 @@ spec:
 {{- if .Values.enabledRBAC }}
   serviceAccountName: {{ default (default (include "app.fullname" .) .Values.serviceAccountName) .Values.serviceAccountNameOverride }}
 {{- end }}
-{{- if .Values.serviceMonitorNamespaceSelector }}
-  serviceMonitorNamespaceSelector:
-{{ toYaml .Values.serviceMonitorNamespaceSelector | indent 4 }}
-{{- end }}
-{{- if .Values.serviceMonitorSelector }}
+{{ include "serviceMonitor.namespace.selector" . | indent 2 }}
+{{- if or (.Values.serviceMonitorSelector) (eq .Values.level "project") }}
   serviceMonitorSelector:
 {{ toYaml .Values.serviceMonitorSelector | indent 4 }}
 {{- end }}
@@ -143,14 +145,8 @@ spec:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     url: {{ printf "%s%s" .Values.sync.target .Values.sync.path }}
 {{- end }}
-{{- if .Values.ruleNamespaceSelector }}
-  ruleNamespaceSelector:
-{{ toYaml .Values.ruleNamespaceSelector | indent 4 }}
-{{- end }}
-{{- if .Values.ruleSelector }}
-  ruleSelector:
-{{ toYaml .Values.ruleSelector | indent 4 }}
-{{- end }}
+{{ include "rule.namespace.selector" . | indent 2}}
+{{ include "rule.selector" . | indent 2 }}
 {{- if or .Values.storageSpec .Values.persistence.enabled }}
   storage:
     volumeClaimTemplate:

--- a/charts/rancher-monitoring/v0.0.3/charts/prometheus/templates/rbac.yaml
+++ b/charts/rancher-monitoring/v0.0.3/charts/prometheus/templates/rbac.yaml
@@ -11,6 +11,7 @@ metadata:
 imagePullSecrets: 
 {{ toYaml .Values.image.pullSecrets | indent 2 }}
 
+{{- if eq .Values.level "cluster" }}
 ---
 apiVersion: {{ template "rbac_api_version" . }}
 kind: ClusterRole
@@ -42,7 +43,6 @@ rules:
   - services
   - endpoints
   - pods
-{{- if eq .Values.level "cluster" }}
   - nodes
 - apiGroups:
   - ""
@@ -65,7 +65,6 @@ rules:
   - subjectaccessreviews
   verbs:
   - "create"
-{{- end }}
 
 ---
 apiVersion: {{ template "rbac_api_version" . }}
@@ -85,71 +84,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ default (include "app.fullname" .) .Values.serviceAccountNameOverride }}
     namespace: {{ .Release.Namespace }}
-
-{{- if eq .Values.level "project" }}
----
-apiVersion: {{ template "rbac_api_version" . }}
-kind: Role
-metadata:
-  labels:
-    app: {{ template "app.name" . }}
-    chart: {{ template "app.version" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ include "app.fullname" . }}
-rules:
-- apiGroups:
-  - "monitoring.cattle.io"
-  resources:
-  - prometheus
-  verbs:
-  - "view"
-
----
-apiVersion: {{ template "rbac_api_version" . }}
-kind: RoleBinding
-metadata:
-  labels:
-    app: {{ template "app.name" . }}
-    chart: {{ template "app.version" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ include "app.fullname" . }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "app.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ default (include "app.fullname" .) .Values.serviceAccountNameOverride }}
-    namespace: {{ .Release.Namespace }}
 {{- end }}
-
-{{- $rbacAPIVersion := include "rbac_api_version" .  }}
-{{- $appServiceAccountName := default (include "app.fullname" .) .Values.serviceAccountNameOverride }}
-{{- $appName := include "app.name" . }}
-{{- $appVersion := include "app.version" . }}
-{{- $root := . -}}
-{{ range .Values.additionalBindingClusterRoles }}
----
-apiVersion: {{ $rbacAPIVersion }}
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app: {{ $appName }}
-    chart: {{ $appVersion }}
-    heritage: {{ $root.Release.Service }}
-    release: {{ $root.Release.Name }}
-  name: {{ . }}-additional-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $appServiceAccountName }}
-    namespace: {{ $root.Release.Namespace }}
-
-{{ end }}
 {{- end }}

--- a/charts/rancher-monitoring/v0.0.3/values.yaml
+++ b/charts/rancher-monitoring/v0.0.3/values.yaml
@@ -32,7 +32,7 @@ exporter-coredns:
   enabled: false
   apiGroup: "monitoring.coreos.com"
   endpoints: []
-  ports: 
+  ports:
     metrics:
       scheme: http
       name: metrics
@@ -46,7 +46,7 @@ exporter-kube-controller-manager:
   enabled: false
   apiGroup: "monitoring.coreos.com"
   endpoints: []
-  ports: 
+  ports:
     metrics:
       scheme: http
       name: metrics
@@ -60,7 +60,7 @@ exporter-kube-dns:
   enabled: false
   apiGroup: "monitoring.coreos.com"
   endpoints: []
-  ports: 
+  ports:
     metrics:
       dnsmasq:
         scheme: http
@@ -80,7 +80,7 @@ exporter-kube-etcd:
   enabled: false
   apiGroup: "monitoring.coreos.com"
   endpoints: []
-  ports: 
+  ports:
     metrics:
       scheme: https
       name: metrics
@@ -97,7 +97,7 @@ exporter-kube-scheduler:
   enabled: false
   apiGroup: "monitoring.coreos.com"
   endpoints: []
-  ports: 
+  ports:
     metrics:
       scheme: http
       name: http-metrics
@@ -120,7 +120,7 @@ exporter-kubelets:
 exporter-kubernetes:
   enabled: false
   apiGroup: "monitoring.coreos.com"
-  ports: 
+  ports:
     metrics:
       scheme: https
       name: https
@@ -132,7 +132,7 @@ exporter-kubernetes:
 exporter-fluentd:
   enabled: false
   apiGroup: "monitoring.coreos.com"
-  ports: 
+  ports:
     metrics:
       scheme: http
       name: metric
@@ -328,9 +328,8 @@ prometheus:
     size: 50Gi
   alertingEndpoints: []
   secrets: []
-  ## Already exist ServiceAccount
+  ## Override the default generated ServiceAccount name
   ##
-  serviceAccountName: ""
   serviceAccountNameOverride: ""
   ruleNamespaceSelector: {}
   ruleSelector:
@@ -346,6 +345,14 @@ prometheus:
     mode: "remote"
     path: "/api/v1/read"
     target: ""
+  project:
+    alertManagerTarget: ""
+    projectDisplayName: ""
+    clusterDisplayName: ""
+  cluster:
+    alertManagerNamespace: ""
 
 global:
   systemDefaultRegistry: ""
+  clusterName: ""
+  projectName: ""

--- a/charts/rancher-monitoring/v0.0.3/values.yaml
+++ b/charts/rancher-monitoring/v0.0.3/values.yaml
@@ -338,7 +338,6 @@ prometheus:
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector:
     matchExpressions: []
-  addtionalBindingClusterRoles: []
   securityContext:
     runAsUser: 1000
     runAsNonRoot: true


### PR DESCRIPTION
Base on PR: https://github.com/rancher/system-charts/pull/36

This PR contains following changes
- Remove RBAC resource from project monitoring charts
- Use the service account injected by Rancher in project monitoring charts

Related issue: https://github.com/rancher/rancher/issues/19381
