### PR TITLE
The node exporter should be listening 0.0.0.0 instead of pod ip

### DIFF
--- a/charts/rancher-monitoring/v0.0.3/charts/exporter-node/templates/daemonset.yaml
+++ b/charts/rancher-monitoring/v0.0.3/charts/exporter-node/templates/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: exporter-node
         image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         args:
-        - --web.listen-address=$(POD_IP):{{ .Values.ports.metrics.port }}
+        - --web.listen-address=0.0.0.0:{{ .Values.ports.metrics.port }}
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
         - --path.rootfs=/host
@@ -46,11 +46,6 @@ spec:
         - --no-collector.{{$collectorName}}
         {{- end }}
         {{- end }}
-        env:
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         ports:
         - name: http
           containerPort: {{ .Values.ports.metrics.port }}


### PR DESCRIPTION
Fix the issue that node exporter crash when deploying
into the node without internal ip.

Related issue:
https://github.com/rancher/rancher/issues/19665