### PR TITLE
Add CI scripts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,13 @@
+kind: pipeline
+name: default
+
+steps:
+- name: build
+  pull: default
+  image: rancher/dapper:v0.4.1
+  commands:
+  - dapper ci
+  privileged: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,47 @@
+FROM ubuntu:18.04
+
+ARG DAPPER_HOST_ARCH
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+ENV CATTLE_HELM_VERSION v2.10.0-rancher10
+
+RUN apt-get update && \
+    apt-get install -y gcc ca-certificates git wget curl vim less file xz-utils unzip && \
+    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+
+RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && \
+    go get -u golang.org/x/lint/golint
+
+ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
+    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
+    DOCKER_URL=DOCKER_URL_${ARCH}
+
+ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/helm \
+    HELM_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/helm-arm64 \
+    HELM_URL=HELM_URL_${ARCH} \
+    TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/tiller \
+    TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/tiller-arm64 \
+    TILLER_URL=TILLER_URL_${ARCH}
+
+RUN curl -sLf ${!HELM_URL} > /usr/bin/helm && \
+    curl -sLf ${!TILLER_URL} > /usr/bin/tiller && \
+    chmod +x /usr/bin/helm /usr/bin/tiller && \
+    helm init -c && \
+    helm plugin install https://github.com/lrills/helm-unittest --version v0.1.5
+
+RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+
+ENV HELM_HOME /root/.helm
+ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_SOURCE /src/github.com/rancher/system-charts/
+ENV DAPPER_OUTPUT ./bin ./dist
+ENV DAPPER_DOCKER_SOCKET true
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+WORKDIR ${DAPPER_SOURCE}
+
+ENTRYPOINT ["./scripts/entry"]

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./build
+./validate
+./test
+./package

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+mkdir -p bin dist
+if [ -e ./scripts/$1 ]; then
+    ./scripts/"$@"
+else
+    exec "$@"
+fi
+
+chown -R $DAPPER_UID:$DAPPER_GID .

--- a/scripts/package
+++ b/scripts/package
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+echo "-- chart/test --"
+
+cd $(dirname $0)/..
+
+# Check for helm
+hash helm >/dev/null 2>&1
+if [[ $? > 0 ]]; then
+    echo "helm not found. Helm is required to run tests."
+    exit 1
+fi
+
+# Check for unittest plugin
+helm unittest --help >/dev/null 2>&1
+if [[ $? > 0 ]]; then
+    echo "helm plugin unittest not found."
+    echo "Run to install plugin: helm plugin install https://github.com/lrills/helm-unittest"
+    exit 1
+fi
+
+do_test(){
+  local name
+  name=`dirname $1 | xargs basename`
+  echo "Testing: $name `basename $1`"
+  helm unittest $1
+}
+
+
+for name in `ls ./charts`
+do
+  for version in `ls ./charts/$name`
+  do
+    if [[ -d ./charts/$name/$version/tests ]];then
+      do_test $PWD/charts/$name/$version
+    fi
+  done
+done

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+echo "-- validate --"
+
+cd $(dirname $0)/..
+
+# Check for helm
+hash helm >/dev/null 2>&1
+if [[ $? > 0 ]]; then
+    echo "helm not found. Helm is required to run tests."
+    exit 1
+fi
+
+do_lint(){
+  # make a link due to the limitation that helm linter does
+  # not allow directory name different from the chart name
+  # see https://github.com/helm/helm/issues/4683
+  local tmpdir name
+  tmpdir=`mktemp -d /tmp/chart.XXXXXXXX`
+  name=`dirname $1 | xargs basename`
+  lndir="$tmpdir/$name"
+  ln -s $1 $lndir 
+  echo "Linting: $name `basename $1`"
+  helm lint $lndir
+}
+
+
+for name in `ls ./charts`
+do
+  for version in `ls ./charts/$name`
+  do
+    do_lint $PWD/charts/$name/$version
+  done
+done
+


### PR DESCRIPTION
Do Helm lint validation and Helm unittest for the charts

It uses the same test tools as the rancher chart, but a newer version of unittest plugin to address some issues of it.
It does linting for all charts, and run unit tests when a `tests` directory is found in a chart directory.