### PR TITLE
Keep the operator charts version to 0.0.2

### DIFF
--- a/charts/rancher-monitoring/v0.0.3/charts/operator/Chart.yaml
+++ b/charts/rancher-monitoring/v0.0.3/charts/operator/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - name: thxCode
   email: frank@rancher.com
 name: operator
-version: 0.0.1
+version: 0.0.2

--- a/charts/rancher-monitoring/v0.0.3/requirements.yaml
+++ b/charts/rancher-monitoring/v0.0.3/requirements.yaml
@@ -65,6 +65,6 @@ dependencies:
     repository: "file://./charts/exporter-fluentd/"
 
   - name: operator
-    version: 0.0.1
+    version: 0.0.2
     condition: operator.enabled,enabled
     repository: "file://./charts/operator/"


### PR DESCRIPTION
**Problem:**
Upgrade the operator would have errors because we change the version of
the operator charts.

**Solution:**
Keep the old version 0.0.2 the operator used before.

Related issue:
https://github.com/rancher/rancher/issues/20301