### PR TITLE
Remove nginx proxy_buffer from Monitoring

### DIFF
--- a/charts/rancher-monitoring/v0.0.3/charts/grafana/templates/nginx-configmap.yaml
+++ b/charts/rancher-monitoring/v0.0.3/charts/grafana/templates/nginx-configmap.yaml
@@ -59,11 +59,7 @@ data:
       proxy_connect_timeout       10;
       proxy_read_timeout          180;
       proxy_send_timeout          5;
-      proxy_buffer_size           16k;
-      proxy_buffers               16 16k;
-      proxy_busy_buffers_size     64k;
-      proxy_temp_file_write_size  64k;
-      proxy_temp_path             /tmp/temp_dir;
+      proxy_buffering             off;
       proxy_cache_path            /tmp/nginx levels=1:2 keys_zone=my_zone:100m inactive=1d max_size=10g;
 
       server {

--- a/charts/rancher-monitoring/v0.0.3/charts/prometheus/templates/nginx-configmap.yaml
+++ b/charts/rancher-monitoring/v0.0.3/charts/prometheus/templates/nginx-configmap.yaml
@@ -41,11 +41,7 @@ data:
       proxy_connect_timeout       10;
       proxy_read_timeout          180;
       proxy_send_timeout          5;
-      proxy_buffer_size           16k;
-      proxy_buffers               16 16k;
-      proxy_busy_buffers_size     64k;
-      proxy_temp_file_write_size  64k;
-      proxy_temp_path             /tmp/temp_dir;
+      proxy_buffering             off;
       proxy_cache_path            /tmp/nginx levels=1:2 keys_zone=my_zone:100m inactive=1d max_size=10g;
 
       server {


### PR DESCRIPTION
**Problem:**
Buffering proxy data causes client to receive slow

**Solution:**
Disable buffer via `proxy_buffering  off;` to response client directly

**Issue:**
https://github.com/rancher/rancher/issues/19689