### PR TITLE
Add Jaeger and grafana external url of Kiali

### DIFF
--- a/charts/rancher-istio/1.1.5-rancher1/charts/kiali/templates/configmap.yaml
+++ b/charts/rancher-istio/1.1.5-rancher1/charts/kiali/templates/configmap.yaml
@@ -25,6 +25,4 @@ data:
         custom_metrics_url: "http://prometheus.{{ .Release.Namespace }}:9090"
         {{- if .Values.dashboard.grafanaURL }}
         url: {{ .Values.dashboard.grafanaURL }}
-        {{- else }}
-        url: "http://prometheus.{{ .Release.Namespace }}:9090"
         {{- end }}

--- a/charts/rancher-istio/1.1.5-rancher1/charts/kiali/templates/deployment.yaml
+++ b/charts/rancher-istio/1.1.5-rancher1/charts/kiali/templates/deployment.yaml
@@ -38,6 +38,16 @@ spec:
         - "-v"
         - "4"
         env:
+        {{- if and .Values.global.rancher (and .Values.global.rancher.domain .Values.global.rancher.clusterId) }}
+        {{- if not .Values.dashboard.jaegerURL }}
+        - name: JAEGER_URL
+          value: 'https://{{ .Values.global.rancher.domain }}/k8s/clusters/{{ .Values.global.rancher.clusterId }}/api/v1/namespaces/{{ .Release.Namespace }}/services/tracing:80/proxy/jaeger'
+        {{- end }}
+        {{- if not .Values.dashboard.grafanaURL }}
+        - name: GRAFANA_URL
+          value: 'https://{{ .Values.global.rancher.domain }}/k8s/clusters/{{ .Values.global.rancher.clusterId }}/api/v1/namespaces/{{ .Release.Namespace }}/services/http:grafana:80/proxy/'
+        {{- end }}
+        {{- end }}
         - name: ACTIVE_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/rancher-istio/1.1.5-rancher1/values.yaml
+++ b/charts/rancher-istio/1.1.5-rancher1/values.yaml
@@ -133,6 +133,12 @@ certmanager:
 
 # Common settings used among istio subcharts.
 global:
+  # Specify rancher domain and clusterId of external tracing config
+  # https://github.com/istio/istio.io/issues/4146#issuecomment-493543032
+  rancher:
+    domain:
+    clusterId:
+
   systemDefaultRegistry: ""
   # Default hub for Istio images.
   # Releases are published to docker hub under 'istio' project.


### PR DESCRIPTION
**Problem:**
User is not able to view external Jaeger or Grafana URL in the Kiali dashboard, it shows a Rancher 404 page.

**Solution:**
as per official reply from https://github.com/istio/istio.io/issues/4146#issuecomment-493543032, the current solution is to add rancher generate Jaeger proxy url to the Kiali and Grafana config.

**Related Issue:**
https://github.com/rancher/rancher/issues/20615