### PR TITLE
Add rbac to istio services of rancher

### DIFF
--- a/charts/rancher-istio/1.1.5-rancher1/templates/istio-service-rbac.yaml
+++ b/charts/rancher-istio/1.1.5-rancher1/templates/istio-service-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: istio-service-reader
+rules:
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    resourceNames: ["http:kiali-http:80", "http:tracing:80", "http:grafana:80", "http:prometheus-http:80"]
+    verbs: ["get", "watch", "list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-istio-service
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: istio-service-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**Problem:**
Rancher project users should be able to access to istio service like Tracing, Kiali service


**Solution:**
Add istio RBAC to istio services of rancher user.

**Related Issues:**
https://github.com/rancher/rancher/issues/20695#event-2392966477