### PR TITLE
Set maxUnavailable to 1 for registry deployment

### DIFF
--- a/charts/harbor/v1.7.5-rancher1/templates/registry/registry-dpl.yaml
+++ b/charts/harbor/v1.7.5-rancher1/templates/registry/registry-dpl.yaml
@@ -11,6 +11,9 @@ spec:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
       component: registry
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/20664

Problem:
Registry pod stuck in AttchVolumeFailed status on upgrade. Deadlock happens where the new pod waits the old pod to dettach the volume, and the old one waits for the new one to be ready.

Solution:
Set maxUnavailable to 1, so that the old pod can be released before the new pod is ready.