### PR TITLE
Update harbor notes.txt

### DIFF
--- a/charts/harbor/v1.7.5-rancher1/templates/NOTES.txt
+++ b/charts/harbor/v1.7.5-rancher1/templates/NOTES.txt
@@ -1,7 +1,9 @@
 Please wait for several minutes for Harbor deployment to complete.
-{{- if .Values.globalRegistryMode -}}
-Then you should be able to visit the Harbor portal at {{ .Values.externalURL }}.
-{{- else -}}
+
+{{- if .Values.globalRegistryMode }}
 Then you should be able to visit the Harbor portal at {{ .Values.externalURL }}/registry.
-{{- end -}}
+{{- else }}
+Then you should be able to visit the Harbor portal at {{ .Values.externalURL }}.
+{{- end }}
+
 For more details, please visit https://github.com/goharbor/harbor.


### PR DESCRIPTION
**Issue:**
The Notes section states "...you should be able to visit the Harbor portal at https://rancherserver.org..."
It should state the correct endpoint (/registry)

**Solution:**
Fix the rendering result of Notes.txt file and add line breaks

**Related Issues:**
https://github.com/rancher/rancher/issues/20735