### PR TITLE
Add persistence.affix option to Harbor chart

### DIFF
--- a/charts/harbor/v1.7.5-rancher1/templates/_helpers.tpl
+++ b/charts/harbor/v1.7.5-rancher1/templates/_helpers.tpl
@@ -284,6 +284,18 @@ host:port,pool_size,password
   {{- printf "%s-ingress-notary" (include "harbor.fullname" .) -}}
 {{- end -}}
 
+{{- define "harbor.data-volume-name" -}}
+  {{- if .Values.persistence.affix }}
+    {{- printf "data-%s" (lower .Values.persistence.affix) -}}
+  {{- else }}
+    {{- "data" -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "harbor.registry-pvc" -}}
+    {{- printf "%s-%s" (include "harbor.data-volume-name" .) (include "harbor.registry" .) -}}
+{{- end -}}
+
 {{- define "harbor.externalURL" -}}
     {{- if eq .Values.expose.type "ingress" }}
       {{- printf "https://%s" .Values.expose.ingress.host -}}

--- a/charts/harbor/v1.7.5-rancher1/templates/database/database-ss.yaml
+++ b/charts/harbor/v1.7.5-rancher1/templates/database/database-ss.yaml
@@ -31,7 +31,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["rm", "-Rf", "/var/lib/postgresql/data/lost+found"]
         volumeMounts:
-        - name: database-data
+        - name: {{ template "harbor.data-volume-name" . }}
           mountPath: /var/lib/postgresql/data
       containers:
       - name: database
@@ -57,16 +57,16 @@ spec:
           - secretRef:
               name: "{{ template "harbor.database" . }}"
         volumeMounts:
-        - name: database-data
+        - name: {{ template "harbor.data-volume-name" . }}
           mountPath: /var/lib/postgresql/data
           subPath: {{ $database.subPath }}
       {{- if not .Values.persistence.enabled }}
       volumes:
-      - name: "database-data"
+      - name: {{ template "harbor.data-volume-name" . }}
         emptyDir: {}
       {{- else if $database.existingClaim }}
       volumes:
-      - name: "database-data"
+      - name: {{ template "harbor.data-volume-name" . }}
         persistentVolumeClaim:
           claimName: {{ $database.existingClaim }}
       {{- end -}}
@@ -86,7 +86,7 @@ spec:
   {{- if and .Values.persistence.enabled (not $database.existingClaim) }}
   volumeClaimTemplates:
   - metadata:
-      name: "database-data"
+      name: {{ template "harbor.data-volume-name" . }}
       labels:
 {{ include "harbor.labels" . | indent 8 }}
     spec:

--- a/charts/harbor/v1.7.5-rancher1/templates/redis/statefulset.yaml
+++ b/charts/harbor/v1.7.5-rancher1/templates/redis/statefulset.yaml
@@ -43,16 +43,16 @@ spec:
 {{ toYaml .Values.redis.internal.resources | indent 10 }}
 {{- end }}
         volumeMounts:
-        - name: data
+        - name: {{ template "harbor.data-volume-name" . }}
           mountPath: /var/lib/redis
           subPath: {{ $redis.subPath }}
       {{- if not .Values.persistence.enabled }}
       volumes:
-      - name: data
+      - name: {{ template "harbor.data-volume-name" . }}
         emptyDir: {}
       {{- else if $redis.existingClaim }}
       volumes:
-      - name: data
+      - name: {{ template "harbor.data-volume-name" . }}
         persistentVolumeClaim:
           claimName: {{ $redis.existingClaim }}
       {{- end -}}
@@ -72,7 +72,7 @@ spec:
   {{- if and .Values.persistence.enabled (not $redis.existingClaim) }}
   volumeClaimTemplates:
   - metadata:
-      name: data
+      name: {{ template "harbor.data-volume-name" . }}
       labels:
 {{ include "harbor.labels" . | indent 8 }}
     spec:

--- a/charts/harbor/v1.7.5-rancher1/templates/registry/registry-dpl.yaml
+++ b/charts/harbor/v1.7.5-rancher1/templates/registry/registry-dpl.yaml
@@ -130,7 +130,7 @@ spec:
       - name: registry-data
       {{- if and .Values.persistence.enabled (eq .Values.imageChartStorage.type "filesystem") }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.persistentVolumeClaim.registry.existingClaim | default (include "harbor.registry" .) }}
+          claimName: {{ .Values.persistence.persistentVolumeClaim.registry.existingClaim | default (include "harbor.registry-pvc" .) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/charts/harbor/v1.7.5-rancher1/templates/registry/registry-pvc.yaml
+++ b/charts/harbor/v1.7.5-rancher1/templates/registry/registry-pvc.yaml
@@ -4,7 +4,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "harbor.registry" . }}
+  name: {{ template "harbor.registry-pvc" . }}
   {{- if eq .Values.persistence.resourcePolicy "keep" }}
   annotations:
     helm.sh/resource-policy: keep

--- a/charts/harbor/v1.7.5-rancher1/values.yaml
+++ b/charts/harbor/v1.7.5-rancher1/values.yaml
@@ -79,6 +79,8 @@ globalRegistryMode: true
 # "swift" or "oss". Set it in the "imageChartStorage" section
 persistence:
   enabled: true
+  # It is added to generated PVC names so that they are different between releases even the release name does not change
+  affix: ""
   # Setting it to "keep" to avoid removing PVCs during a helm delete
   # operation. Leaving it empty will delete PVCs after the chart deleted
   resourcePolicy: "keep"


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/20694

Problem:
Global registry uses existing PVCs from previous release, even storageclass changed on
re-enabling. Because the PVC names remain the same. In helm style, release name is usually used to avoid resources
conflicts. But we want to keep app name consistent and the release name
is bound to the app name.

Solution:
Add the option to specify affix for PVC names. UI can set a random
alphabet-number string to it on enabling, and keep it on updates. So
that every time registry is enabled, fresh PVCs are used.