### PR TITLE
[Harbor] Add hook to clean up PVCs on deletion

### DIFF
--- a/charts/harbor/v1.7.5-rancher1/templates/_helpers.tpl
+++ b/charts/harbor/v1.7.5-rancher1/templates/_helpers.tpl
@@ -56,6 +56,16 @@ app: "{{ template "harbor.name" . }}"
   {{- end -}}
 {{- end -}}
 
+{{- define "harbor.autoRemovePVCs" -}}
+  {{- with .Values.persistence.persistentVolumeClaim -}}
+    {{- if and $.Values.persistence.enabled (ne $.Values.persistence.resourcePolicy "keep") (or (eq .database.existingClaim "") (eq .redis.existingClaim "")) -}}
+      {{- printf "true" -}}
+    {{- else -}}
+      {{- printf "false" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "harbor.database.host" -}}
   {{- if eq .Values.database.type "internal" -}}
     {{- template "harbor.database" . }}

--- a/charts/harbor/v1.7.5-rancher1/templates/hook/job.yaml
+++ b/charts/harbor/v1.7.5-rancher1/templates/hook/job.yaml
@@ -1,0 +1,36 @@
+{{- if eq (include "harbor.autoRemovePVCs" .) "true" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed"
+    "helm.sh/hook-weight": "3"
+  name: {{ .Release.Name }}-cleanup
+  namespace: {{ .Release.Namespace }}
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 1
+  template:
+    metadata:
+      name: cleanup
+    spec:
+      containers:
+      - name: cleanup
+        image: bitnami/kubectl:1.14.1
+        imagePullPolicy: Always
+        command:
+        - kubectl
+        - -n
+        - {{ .Release.Namespace }}
+        - delete
+        {{- if eq .Values.persistence.persistentVolumeClaim.database.existingClaim "" }}
+        - pvc/database-data-{{ template "harbor.database" . }}-0
+        {{- end }}
+        {{- if eq .Values.persistence.persistentVolumeClaim.redis.existingClaim "" }}
+        - pvc/data-{{ template "harbor.redis" . }}-0
+        {{- end }}
+        - --ignore-not-found=true
+      serviceAccountName: {{ .Release.Name }}-cleanup-sa
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/harbor/v1.7.5-rancher1/templates/hook/rbac.yaml
+++ b/charts/harbor/v1.7.5-rancher1/templates/hook/rbac.yaml
@@ -1,0 +1,50 @@
+{{- if eq (include "harbor.autoRemovePVCs" .) "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed"
+    "helm.sh/hook-weight": "1"
+  name: {{ .Release.Name }}-cleanup-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed"
+    "helm.sh/hook-weight": "1"
+  name: {{ .Release.Name }}-cleanup-r
+rules:
+- apiGroups: [""]
+  resources: 
+  - persistentvolumeclaims
+  - serviceaccounts
+  verbs:
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed"
+    "helm.sh/hook-weight": "2"
+  name: {{ .Release.Name }}-cleanup-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-cleanup-r
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-cleanup-sa
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/harbor/v1.7.5-rancher1/values.yaml
+++ b/charts/harbor/v1.7.5-rancher1/values.yaml
@@ -81,7 +81,7 @@ persistence:
   enabled: true
   # Setting it to "keep" to avoid removing PVCs during a helm delete
   # operation. Leaving it empty will delete PVCs after the chart deleted
-  resourcePolicy: "keep"
+  resourcePolicy: ""
   persistentVolumeClaim:
     registry:
       # Use the existing PVC which must be created manually before bound, 


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/20694

Statefulset PVCs are not managed in Helm release lifecycle. To remove auto provisioned PVCs on disabling registry, add a post-delete hook to the chart.

The hook does not clean up existing PVCs created by users outside the chart.