### PR TITLE
Access control for Istio services

### DIFF
--- a/charts/rancher-istio/0.0.2/templates/istio-service-rbac.yaml
+++ b/charts/rancher-istio/0.0.2/templates/istio-service-rbac.yaml
@@ -10,17 +10,20 @@ rules:
     verbs: ["get", "watch", "list"]
 
 ---
-
+{{- if .Values.global.members }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: read-istio-service
   namespace: {{ .Release.Namespace }}
 subjects:
-  - kind: Group
-    name: system:authenticated
+  {{- range $member := .Values.global.members }}
+  - kind: {{ $member.kind }}
+    name: {{ $member.name }}
     apiGroup: rbac.authorization.k8s.io
+  {{- end }}
 roleRef:
   kind: Role
   name: istio-service-reader
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/rancher-istio/0.0.2/values.yaml
+++ b/charts/rancher-istio/0.0.2/values.yaml
@@ -139,6 +139,12 @@ istiocoredns:
 
 # Common settings used among istio subcharts.
 global:
+  # Specify members that can access istio service proxy
+  # members:
+  # - kind: User
+  #   name: u-abcba
+  # - kind: Group
+  #   name: github_org://1234567
   # Specify rancher domain and clusterId of external tracing config
   # https://github.com/istio/istio.io/issues/4146#issuecomment-493543032
   rancher:


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/20895

Formerly, it is accessible by authenticated users.
Now, it is accessible by cluster owners and authorized users/groups.