### PR TITLE
Update prometheus and grafana image and fixed prom spec

### DIFF
--- a/charts/rancher-monitoring/v0.0.4/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.4/charts/prometheus/templates/prometheus.yaml
@@ -80,6 +80,9 @@ spec:
   listenLocal: true
 {{- end }}
   podMetadata:
+    {{- if .Release.IsInstall }}
+    creationTimestamp: {{ now | date "2006-01-02T15:04:05Z" | quote }}
+    {{- end }}
     labels:
       app: {{ template "app.name" . }}
       chart: {{ template "app.version" . }}

--- a/charts/rancher-monitoring/v0.0.4/values.yaml
+++ b/charts/rancher-monitoring/v0.0.4/values.yaml
@@ -232,7 +232,7 @@ grafana:
   apiGroup: "monitoring.coreos.com"
   image:
     repository: rancher/grafana-grafana
-    tag: 5.4.3
+    tag: 6.3.2
     tool:
       repository: rancher/prometheus-auth
       tag: v0.2.0
@@ -290,7 +290,7 @@ prometheus:
   apiGroup: "monitoring.coreos.com"
   image:
     repository: rancher/prom-prometheus
-    tag: v2.7.1
+    tag: v2.11.1
     auth:
       repository: rancher/prometheus-auth
       tag: v0.2.0


### PR DESCRIPTION
**TODO:**
Push required images to rancher's docker hub:
```
prom/prometheus:v2.11.1 -> rancher/prom-prometheus:v2.11.1
grafana/grafana:6.3.2 -> rancher/grafana-grafana: 6.3.2
```

**Related Issue:**
1. Update Prometheus and Grafana image to the latest version
https://github.com/rancher/rancher/issues/21827
2. Prometheus creationTimestamp is required for its podMetadata.
https://github.com/rancher/rancher/issues/21964

**Solution:**
1. Update Prometheus version from `v2.7.1` to `v.2.11.1`
2. Update Grafana version from `5.4.3` to `6.3.2`
2. Add default creationTimestamp of Prometheus object
