### PR TITLE
Enhance logging charts compatible

### DIFF
--- a/charts/rancher-logging/0.1.2/charts/fluentd-tester/templates/deployment.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd-tester/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "fluentd-tester.name" . }}
-      chart: {{ template "fluentd-tester.version" . }}
       release: {{ .Release.Name }}
   template:
     metadata:

--- a/charts/rancher-logging/0.1.2/charts/fluentd/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/templates/daemonset.yaml
@@ -18,7 +18,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "fluentd.name" . }}
-      chart: {{ template "fluentd.version" . }}
       release: {{ .Release.Name }}
   template:
     metadata:

--- a/charts/rancher-logging/0.1.2/charts/log-aggregator/templates/log-aggregator.yaml
+++ b/charts/rancher-logging/0.1.2/charts/log-aggregator/templates/log-aggregator.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "daemonset_api_version" . }}
 kind: DaemonSet
 metadata:
   name: {{ template "log-aggregator.fullname" . }}
@@ -18,7 +18,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "log-aggregator.name" . }}
-      chart: {{ template "log-aggregator.version" . }}
       release: {{ .Release.Name }}
   template:
     metadata:


### PR DESCRIPTION
Upgrade rancher-logging chart API version to be k8s v1.16 compatible

Problem:
Daemonset api version extensions/v1beta1 is deperated in 1.16

Solution:
Use the capabilities API versions defined in the template

Issue:
https://github.com/rancher/rancher/issues/21770