### PR TITLE
Add required selector matchLabels for external-dns of apps/v1

### DIFF
--- a/charts/rancher-external-dns/v0.0.2/templates/deployment.yaml
+++ b/charts/rancher-external-dns/v0.0.2/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   name: {{ template "external-dns.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      {{ include "external-dns.labels" . | indent 6 }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Issue:
```
Failed to install app rancher-external-dns. Error: release rancher-external-dns failed: Deployment.apps "rancher-external-dns" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{"app":"rancher-external-dns", "heritage":"Tiller", "release":"rancher-external-dns"}: `selector` does not match template `labels`]
```
Solution:
Add default selector matchLabels for the `apps/v1` apiVersion.

**Related Issue:**
https://github.com/rancher/rancher/issues/21768
