### PR TITLE
Upgrade fluentd images since we release new version

### DIFF
--- a/charts/rancher-logging/0.1.2/charts/fluentd-tester/values.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd-tester/values.yaml
@@ -2,7 +2,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.13
+  tag: v0.1.14
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/rancher-logging/0.1.2/charts/fluentd/values.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/values.yaml
@@ -2,7 +2,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.13
+  tag: v0.1.14
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
Problem:
current elasticsearch gems has warning log for elasticsearch 7.x, rancher/fluentd have release new version

Solution:
upgrade fluentd, elasticsearch etc gems version

Issue:
https://github.com/rancher/rancher/issues/20450
https://github.com/rancher/rancher/issues/20509