### PR TITLE
Bump istio to v1.2.5

### DIFF
--- a/charts/rancher-istio/0.0.2/Chart.yaml
+++ b/charts/rancher-istio/0.0.2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rancher-istio
 version: 0.0.2
-appVersion: 1.2.4
+appVersion: 1.2.5
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for all istio components
 home: https://istio.io/

--- a/charts/rancher-istio/0.0.2/Chart.yaml
+++ b/charts/rancher-istio/0.0.2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rancher-istio
 version: 0.0.2
-appVersion: 1.2.0
+appVersion: 1.2.4
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for all istio components
 home: https://istio.io/

--- a/charts/rancher-istio/0.0.2/charts/certmanager/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/certmanager/templates/deployment.yaml
@@ -54,7 +54,6 @@ spec:
               fieldPath: metadata.namespace
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-      
       {{- if .Values.podDnsPolicy }}
       dnsPolicy: {{ .Values.podDnsPolicy }}
       {{- end }}
@@ -68,4 +67,7 @@ spec:
 {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/galley/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/galley/templates/deployment.yaml
@@ -111,7 +111,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/gateways/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/gateways/templates/deployment.yaml
@@ -156,6 +156,10 @@ spec:
           {{- else }}
           - istio-pilot:15010
           {{- end }}
+          {{- if $spec.applicationPorts }}
+          - --applicationPorts
+          - "{{ $spec.applicationPorts }}"
+          {{- end }}
         {{- end }}
         {{- if $.Values.global.trustDomain }}
           - --trust-domain={{ $.Values.global.trustDomain }}
@@ -290,10 +294,13 @@ spec:
       affinity:
       {{- include "gatewaynodeaffinity" (dict "root" $ "nodeSelector" $spec.nodeSelector) | indent 6 }}
       {{- include "gatewaypodAntiAffinity" (dict "podAntiAffinityLabelSelector" $spec.podAntiAffinityLabelSelector "podAntiAffinityTermLabelSelector" $spec.podAntiAffinityTermLabelSelector) | indent 6 }}
-{{- if $spec.tolerations }}
+      {{- if $spec.tolerations }}
       tolerations:
 {{ toYaml $spec.tolerations | indent 6 }}
-{{- end }}
+      {{- else if $.Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml $.Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/charts/rancher-istio/0.0.2/charts/grafana/templates/create-custom-resources-job.yaml
@@ -93,4 +93,11 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
 {{- end -}}

--- a/charts/rancher-istio/0.0.2/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/grafana/templates/deployment.yaml
@@ -120,10 +120,13 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/rancher-istio/0.0.2/charts/grafana/templates/tests/test-grafana-connection.yaml
+++ b/charts/rancher-istio/0.0.2/charts/grafana/templates/tests/test-grafana-connection.yaml
@@ -27,4 +27,11 @@ spec:
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}
     {{- include "podAntiAffinity" . | indent 4 }}
+  {{- if .Values.tolerations }}
+  tolerations:
+{{ toYaml .Values.tolerations | indent 2 }}
+  {{- else if .Values.global.defaultTolerations }}
+  tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/istio-init/files/crd-10.yaml
+++ b/charts/rancher-istio/0.0.2/charts/istio-init/files/crd-10.yaml
@@ -152,27 +152,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: sidecars.networking.istio.io
-  labels:
-    app: istio-pilot
-    chart: istio
-    heritage: Tiller
-    release: istio
-spec:
-  group: networking.istio.io
-  names:
-    kind: Sidecar
-    plural: sidecars
-    singular: sidecar
-    categories:
-    - istio-io
-    - networking-istio-io
-  scope: Namespaced
-  version: v1alpha3 
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: envoyfilters.networking.istio.io
   labels:
     app: istio-pilot

--- a/charts/rancher-istio/0.0.2/charts/istiocoredns/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/istiocoredns/templates/deployment.yaml
@@ -87,7 +87,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/kiali/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/kiali/templates/deployment.yaml
@@ -111,3 +111,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/kiali/templates/tests/test-kiali-connection.yaml
+++ b/charts/rancher-istio/0.0.2/charts/kiali/templates/tests/test-kiali-connection.yaml
@@ -27,4 +27,11 @@ spec:
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}
     {{- include "podAntiAffinity" . | indent 4 }}
+  {{- if .Values.tolerations }}
+  tolerations:
+{{ toYaml .Values.tolerations | indent 2 }}
+  {{- else if .Values.global.defaultTolerations }}
+  tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/kiali/values.yaml
+++ b/charts/rancher-istio/0.0.2/charts/kiali/values.yaml
@@ -5,6 +5,7 @@ enabled: false # Note that if using the demo or demo-auth yaml when installing v
 replicaCount: 1
 contextPath: /
 nodeSelector: {}
+tolerations: []
 
 # Specify the pod anti-affinity that allows you to constrain which nodes
 # your pod is eligible to be scheduled based on labels on pods that are

--- a/charts/rancher-istio/0.0.2/charts/mixer/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/mixer/templates/deployment.yaml
@@ -32,10 +32,13 @@
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
       containers:
       - name: mixer
         image: "{{ template "system_default_registry" . }}{{ $.Values.repository }}:{{ $.Values.tag }}"
@@ -204,10 +207,13 @@
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
       containers:
       - name: mixer
         image: "{{ template "system_default_registry" . }}{{ $.Values.repository }}:{{ $.Values.tag }}"

--- a/charts/rancher-istio/0.0.2/charts/nodeagent/templates/daemonset.yaml
+++ b/charts/rancher-istio/0.0.2/charts/nodeagent/templates/daemonset.yaml
@@ -51,8 +51,12 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
+  updateStrategy:
+    type: RollingUpdate

--- a/charts/rancher-istio/0.0.2/charts/pilot/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/pilot/templates/deployment.yaml
@@ -208,7 +208,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/prometheus/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/prometheus/templates/deployment.yaml
@@ -100,8 +100,11 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
 {{- end -}}

--- a/charts/rancher-istio/0.0.2/charts/prometheus/templates/tests/test-prometheus-connection.yaml
+++ b/charts/rancher-istio/0.0.2/charts/prometheus/templates/tests/test-prometheus-connection.yaml
@@ -26,4 +26,11 @@ spec:
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}
     {{- include "podAntiAffinity" . | indent 4 }}
+  {{- if .Values.tolerations }}
+  tolerations:
+{{ toYaml .Values.tolerations | indent 2 }}
+  {{- else if .Values.global.defaultTolerations }}
+  tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/security/templates/cleanup-secrets.yaml
+++ b/charts/rancher-istio/0.0.2/charts/security/templates/cleanup-secrets.yaml
@@ -116,3 +116,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/security/templates/create-custom-resources-job.yaml
+++ b/charts/rancher-istio/0.0.2/charts/security/templates/create-custom-resources-job.yaml
@@ -91,4 +91,11 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/security/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/security/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     istio: citadel
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       istio: citadel
@@ -39,6 +39,9 @@ spec:
           image: "{{ template "system_default_registry" . }}{{ .Values.repository }}:{{ .Values.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
+          {{- if .Values.global.sds.enabled }}
+            - --sds-enabled=true
+          {{- end }}
             - --append-dns-names=true
             - --grpc-port=8060
             - --citadel-storage-namespace={{ .Release.Namespace }}
@@ -55,6 +58,9 @@ spec:
           {{- end }}
           {{- if .Values.global.trustDomain }}
             - --trust-domain={{ .Values.global.trustDomain }}
+          {{- end }}
+          {{- if .Values.workloadCertTtl }}
+            - --workload-cert-ttl={{ .Values.workloadCertTtl }}
           {{- end }}
           {{- if .Values.citadelHealthCheck }}
             - --liveness-probe-path=/tmp/ca.liveness # path to the liveness health check status file
@@ -92,7 +98,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
-{{- if .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/security/templates/tests/test-citadel-connection.yaml
+++ b/charts/rancher-istio/0.0.2/charts/security/templates/tests/test-citadel-connection.yaml
@@ -26,4 +26,11 @@ spec:
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}
     {{- include "podAntiAffinity" . | indent 4 }}
+  {{- if .Values.tolerations }}
+  tolerations:
+{{ toYaml .Values.tolerations | indent 2 }}
+  {{- else if .Values.global.defaultTolerations }}
+  tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/security/templates/tests/test-citadel-connection.yaml
+++ b/charts/rancher-istio/0.0.2/charts/security/templates/tests/test-citadel-connection.yaml
@@ -21,7 +21,7 @@ spec:
     - name: "{{ template "security.fullname" . }}-test"
       image: "{{ template "system_default_registry" . }}{{ .Values.global.proxy.repository }}:{{ .Values.global.proxy.tag }}"
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-      command: ['sh', '-c', 'for i in 1 2 3; do curl http://istio-citadel:8060/-/ready && exit 0 || sleep 15; done; exit 1']
+      command: ['sh', '-c', 'for i in 1 2 3; do curl http://istio-citadel:{{ .Values.global.monitoringPort }}/version && exit 0 || sleep 15; done; exit 1']
   restartPolicy: Never
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}

--- a/charts/rancher-istio/0.0.2/charts/security/values.yaml
+++ b/charts/rancher-istio/0.0.2/charts/security/values.yaml
@@ -2,6 +2,7 @@
 # security configuration
 #
 enabled: true
+replicaCount: 1
 selfSigned: true # indicate if self-signed CA is used.
 createMeshPolicy: true
 nodeSelector: {}
@@ -9,6 +10,8 @@ tolerations: []
 # Enable health checking on the Citadel CSR signing API.
 # https://istio.io/docs/tasks/security/health-check/
 citadelHealthCheck: false
+# 90*24hour = 2160h
+workloadCertTtl: 2160h
 
 # Specify the pod anti-affinity that allows you to constrain which nodes
 # your pod is eligible to be scheduled based on labels on pods that are

--- a/charts/rancher-istio/0.0.2/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/charts/rancher-istio/0.0.2/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -97,3 +97,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}

--- a/charts/rancher-istio/0.0.2/charts/sidecarInjectorWebhook/values.yaml
+++ b/charts/rancher-istio/0.0.2/charts/sidecarInjectorWebhook/values.yaml
@@ -5,6 +5,7 @@ enabled: true
 replicaCount: 1
 enableNamespacesByDefault: false
 nodeSelector: {}
+tolerations: []
 
 # Specify the pod anti-affinity that allows you to constrain which nodes
 # your pod is eligible to be scheduled based on labels on pods that are

--- a/charts/rancher-istio/0.0.2/charts/tracing/templates/deployment-jaeger.yaml
+++ b/charts/rancher-istio/0.0.2/charts/tracing/templates/deployment-jaeger.yaml
@@ -109,4 +109,11 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
 {{ end }}

--- a/charts/rancher-istio/0.0.2/charts/tracing/templates/deployment-zipkin.yaml
+++ b/charts/rancher-istio/0.0.2/charts/tracing/templates/deployment-zipkin.yaml
@@ -99,4 +99,11 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+      {{- end }}
 {{ end }}

--- a/charts/rancher-istio/0.0.2/charts/tracing/templates/nginx-configmap.yaml
+++ b/charts/rancher-istio/0.0.2/charts/tracing/templates/nginx-configmap.yaml
@@ -54,7 +54,7 @@ data:
           proxy_pass     http://localhost:16686/;
 {{ else }}
           proxy_pass     http://localhost:9411/;
-{{ end}}      
+{{ end }}
           if ($request_filename ~ .*\.(?:js|css|jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm)$) {
             expires             90d;
           }

--- a/charts/rancher-istio/0.0.2/charts/tracing/values.yaml
+++ b/charts/rancher-istio/0.0.2/charts/tracing/values.yaml
@@ -5,6 +5,7 @@ enabled: false
 
 provider: jaeger
 nodeSelector: {}
+tolerations: []
 
 # Specify the pod anti-affinity that allows you to constrain which nodes
 # your pod is eligible to be scheduled based on labels on pods that are

--- a/charts/rancher-istio/0.0.2/questions.yml
+++ b/charts/rancher-istio/0.0.2/questions.yml
@@ -1,2 +1,2 @@
 labels:
-  rancher.istio.v0.0.2: 1.2.4
+  rancher.istio.v0.0.2: 1.2.5

--- a/charts/rancher-istio/0.0.2/questions.yml
+++ b/charts/rancher-istio/0.0.2/questions.yml
@@ -1,2 +1,2 @@
 labels:
-  rancher.istio.v0.0.2: 1.2.0
+  rancher.istio.v0.0.2: 1.2.4

--- a/charts/rancher-istio/0.0.2/values.yaml
+++ b/charts/rancher-istio/0.0.2/values.yaml
@@ -26,7 +26,7 @@ gateways:
 #
 sidecarInjectorWebhook:
   repository: rancher/istio-sidecar_injector
-  tag: "1.2.0"
+  tag: "1.2.4"
   enabled: true
 
 #
@@ -35,7 +35,7 @@ sidecarInjectorWebhook:
 #
 galley:
   repository: rancher/istio-galley
-  tag: 1.2.0
+  tag: 1.2.4
   enabled: true
 
 #
@@ -44,7 +44,7 @@ galley:
 # @see charts/mixer/values.yaml, it takes precedence
 mixer:
   repository: rancher/istio-mixer
-  tag: "1.2.0"
+  tag: "1.2.4"
   enabled: true
   policy:
     # if policy is enabled the global.disablePolicyChecks has affect.
@@ -58,7 +58,7 @@ mixer:
 # @see charts/pilot/values.yaml
 pilot:
   repository: rancher/istio-pilot
-  tag: "1.2.0"
+  tag: "1.2.4"
   enabled: true
 
 #
@@ -66,7 +66,7 @@ pilot:
 #
 security:
   repository: rancher/istio-citadel
-  tag: "1.2.0"
+  tag: "1.2.4"
   enabled: true
 
 #
@@ -160,7 +160,7 @@ global:
 
   # Default tag for Istio images.
   # tag: release-1.1-latest-daily
-  tag: 1.2.0
+  tag: 1.2.4
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components
@@ -170,7 +170,7 @@ global:
 
   kubectl:
     repository: rancher/istio-kubectl
-    tag: 1.2.0
+    tag: 1.2.4
 
   # monitoring port used by mixer, pilot, galley
   monitoringPort: 15014
@@ -194,7 +194,7 @@ global:
 
   proxy:
     repository: rancher/istio-proxyv2
-    tag: 1.2.0
+    tag: 1.2.4
 
     # cluster domain. Default value is "cluster.local".
     clusterDomain: "cluster.local"
@@ -308,7 +308,7 @@ global:
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     repository: rancher/istio-proxy_init
-    tag: "1.2.0"
+    tag: "1.2.4"
 
   # imagePullPolicy is applied to istio control plane components.
   # local tests require IfNotPresent, to avoid uploading to dockerhub.
@@ -388,6 +388,14 @@ global:
   # values by adding its node selector block in the relevant section below and setting
   # the desired values.
   defaultNodeSelector: {}
+
+  # Default node tolerations to be applied to all deployments so that all pods can be
+  # scheduled to a particular nodes with matching taints. Each component can overwrite
+  # these default values by adding its tolerations block in the relevant section below
+  # and setting the desired values.
+  # Configure this field in case that all pods of Istio control plane are expected to
+  # be scheduled to particular nodes with specified taints.
+  defaultTolerations: []
 
   # Whether to perform server-side validation of configuration.
   configValidation: true
@@ -483,7 +491,7 @@ global:
 
   nodeAgent:
     repository: rancher/istio-node-agent-k8s
-    tag: "1.2.0"
+    tag: "1.2.4"
   sds:
     # SDS enabled. IF set to true, mTLS certificates for the sidecars will be
     # distributed through the SecretDiscoveryService instead of using K8S secrets to mount the certificates.

--- a/charts/rancher-istio/0.0.2/values.yaml
+++ b/charts/rancher-istio/0.0.2/values.yaml
@@ -26,7 +26,7 @@ gateways:
 #
 sidecarInjectorWebhook:
   repository: rancher/istio-sidecar_injector
-  tag: "1.2.4"
+  tag: "1.2.5"
   enabled: true
 
 #
@@ -35,7 +35,7 @@ sidecarInjectorWebhook:
 #
 galley:
   repository: rancher/istio-galley
-  tag: 1.2.4
+  tag: 1.2.5
   enabled: true
 
 #
@@ -44,7 +44,7 @@ galley:
 # @see charts/mixer/values.yaml, it takes precedence
 mixer:
   repository: rancher/istio-mixer
-  tag: "1.2.4"
+  tag: "1.2.5"
   enabled: true
   policy:
     # if policy is enabled the global.disablePolicyChecks has affect.
@@ -58,7 +58,7 @@ mixer:
 # @see charts/pilot/values.yaml
 pilot:
   repository: rancher/istio-pilot
-  tag: "1.2.4"
+  tag: "1.2.5"
   enabled: true
 
 #
@@ -66,7 +66,7 @@ pilot:
 #
 security:
   repository: rancher/istio-citadel
-  tag: "1.2.4"
+  tag: "1.2.5"
   enabled: true
 
 #
@@ -160,7 +160,7 @@ global:
 
   # Default tag for Istio images.
   # tag: release-1.1-latest-daily
-  tag: 1.2.4
+  tag: 1.2.5
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components
@@ -170,7 +170,7 @@ global:
 
   kubectl:
     repository: rancher/istio-kubectl
-    tag: 1.2.4
+    tag: 1.2.5
 
   # monitoring port used by mixer, pilot, galley
   monitoringPort: 15014
@@ -194,7 +194,7 @@ global:
 
   proxy:
     repository: rancher/istio-proxyv2
-    tag: 1.2.4
+    tag: 1.2.5
 
     # cluster domain. Default value is "cluster.local".
     clusterDomain: "cluster.local"
@@ -308,7 +308,7 @@ global:
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     repository: rancher/istio-proxy_init
-    tag: "1.2.4"
+    tag: "1.2.5"
 
   # imagePullPolicy is applied to istio control plane components.
   # local tests require IfNotPresent, to avoid uploading to dockerhub.
@@ -491,7 +491,7 @@ global:
 
   nodeAgent:
     repository: rancher/istio-node-agent-k8s
-    tag: "1.2.4"
+    tag: "1.2.5"
   sds:
     # SDS enabled. IF set to true, mTLS certificates for the sidecars will be
     # distributed through the SecretDiscoveryService instead of using K8S secrets to mount the certificates.


### PR DESCRIPTION
**Issue:**
Bump istio to v1.2.5

**prerequisite:**
push the following images to rancher registry
```
docker pull istio/sidecar_injector:1.2.4
docker tag istio/sidecar_injector:1.2.4 rancher/istio-sidecar_injector:1.2.4
docker push rancher/istio-sidecar_injector:1.2.4

docker pull istio/galley:1.2.4
docker tag istio/galley:1.2.4 rancher/istio-galley:1.2.4
docker push rancher/istio-galley:1.2.4

docker pull istio/mixer:1.2.4
docker tag istio/mixer:1.2.4 rancher/istio-mixer:1.2.4
docker push rancher/istio-mixer:1.2.4

docker pull istio/pilot:1.2.4
docker tag istio/pilot:1.2.4 rancher/istio-pilot:1.2.4
docker push rancher/istio-pilot:1.2.4

docker pull istio/citadel:1.2.4
docker tag istio/citadel:1.2.4 rancher/istio-citadel:1.2.4
docker push rancher/istio-citadel:1.2.4

docker pull istio/kubectl:1.2.4
docker tag istio/kubectl:1.2.4 rancher/istio-kubectl:1.2.4
docker push rancher/istio-kubectl:1.2.4

docker pull istio/proxyv2:1.2.4
docker tag istio/proxyv2:1.2.4 rancher/istio-proxyv2:1.2.4
docker push rancher/istio-proxyv2:1.2.4

docker pull istio/proxy_init:1.2.4
docker tag istio/proxy_init:1.2.4 rancher/istio-proxy_init:1.2.4
docker push rancher/istio-proxy_init:1.2.4

docker pull istio/node-agent-k8s:1.2.4
docker tag istio/node-agent-k8s:1.2.4 rancher/istio-node-agent-k8s:1.2.4
docker push rancher/istio-node-agent-k8s:1.2.4
```


**Related Issue:**
https://github.com/rancher/rancher/issues/21487