### PR TITLE
Add delete istio sidecards crd

### DIFF
--- a/charts/rancher-istio/0.0.2/charts/istio-init/templates/job-crd-11.yaml
+++ b/charts/rancher-istio/0.0.2/charts/istio-init/templates/job-crd-11.yaml
@@ -29,3 +29,37 @@ spec:
         configMap:
           name: istio-crd-11
       restartPolicy: OnFailure
+
+{{- if .Values.deleteCRDs }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: istio-init-delete-crd-11
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-delete-policy": "hook-succeeded, before-hook-creation, hook-failed"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-init-service-account
+      containers:
+      - name: istio-init-crd-11
+        image: "{{ template "system_default_registry" . }}{{ .Values.global.kubectl.repository }}:{{ .Values.global.kubectl.tag }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        volumeMounts:
+        - name: crd-11
+          mountPath: /etc/istio/crd-11
+          readOnly: true
+        command: ["kubectl",  "delete", "-f", "/etc/istio/crd-11/crd-11.yaml"]
+      volumes:
+      - name: crd-11
+        configMap:
+          name: istio-crd-11
+      restartPolicy: Never
+  backoffLimit: 1
+{{- end }}


### PR DESCRIPTION
**Problem:**
isito `sidecards` crd is not removed due to v1.2.5 CRDs changes.

**Solution:**
Add `pre-delete`  job to delete istio sidecards.networking CRD.

**Related Issue:**
https://github.com/rancher/rancher/issues/22542