### PR TITLE
change fluentd windows init container command

### DIFF
--- a/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
         command:
           - 'powershell'
           - '-command'
-          - 'mkdir -p /var/lib/rancher/fluentd/log'
+          - 'New-Item -ItemType Directory -Force -Path /var/lib/rancher/fluentd/log'
         volumeMounts:
         - mountPath: /var/lib/rancher
           name: rancher


### PR DESCRIPTION
Problem:
windows will throws error when the file already exist, which is different from linux

Solution:
change to use new-item

Issue:
https://github.com/rancher/rancher/issues/22679