### PR TITLE
Add host path variable

### DIFF
--- a/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
@@ -145,25 +145,25 @@ spec:
       terminationGracePeriodSeconds: 30
       volumes:
       - hostPath:
-          path: /var/lib/rancher/fluentd/etc/config/custom
+          path: {{ .Values.cluster.custom }}
         name: custom
       - hostPath:
           path: {{ .Values.cluster.dockerRoot }}
         name: dockerroot
       - hostPath:
-          path: /var/log/containers
+          path: {{ .Values.cluster.varlogcontainers }}
         name: varlogcontainers
       - hostPath:
-          path: /var/log/pods
+          path: {{ .Values.cluster.varlogpods }}
         name: varlogpods
       - hostPath:
-          path: /var/lib/rancher/rke/log
+          path: {{ .Values.cluster.rkelog }}
         name: rkelog
       - hostPath:
-          path: /var/lib/rancher/log-volumes
+          path: {{ .Values.cluster.customlog }}
         name: customlog
       - hostPath:
-          path: /var/lib/rancher/fluentd/log
+          path: {{ .Values.cluster.fluentdlog }}
         name: fluentdlog
       - name: config
         secret:
@@ -176,7 +176,7 @@ spec:
           secretName: {{ template "fluentd.fullname" . }}-ssl
       - name: libsystemddir
         hostPath:
-          path: /usr/lib64
+          path: {{ .Values.cluster.libsystemddir }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 6 }}
 {{- end }}

--- a/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-linux/values.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-linux/values.yaml
@@ -40,6 +40,13 @@ service:
 
 cluster:
   dockerRoot: /var/lib/docker
+  custom: /var/lib/rancher/fluentd/etc/config/custom
+  varlogcontainers: /var/log/containers
+  varlogpods: /var/log/pods
+  rkelog: /var/lib/rancher/rke/log
+  customlog: /var/lib/rancher/log-volumes
+  fluentdlog: /var/lib/rancher/fluentd/log
+  libsystemddir: /usr/lib64
 
 service:
   ports:


### PR DESCRIPTION
### Problem:
In a production environment, most users use external mounted disks to store data, so the host path is not necessarily the standard path. 

### Solution:
This PR specifies the host path through a variable, allowing the user flexibility to modify it.

### Related Issue:
https://github.com/rancher/rancher/issues/22741