### PR TITLE
feature: support turning on thanos using prometheus operator

### DIFF
--- a/charts/rancher-monitoring/v0.0.4/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.4/charts/prometheus/templates/prometheus.yaml
@@ -108,6 +108,10 @@ spec:
     {{ $key }}: {{ $value | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.thanos }}
+  thanos: 
+{{ toYaml .Values.thanos | indent 4 }}
+{{- end }}
   nodeSelector:
 {{- include "linux-node-selector" . | nindent 4 }}
     {{- range .Values.nodeSelectors }}


### PR DESCRIPTION
This is a very basic change to allow an admin to turn on thanos using the prometheus operator.

**Note:** If Rancher is interested in a more first class support of turning on Thanos in the UI and allowing the object config being configured via the UI I can help submit another PR that modifies the helm chart further.

To use thanos v0.5.0 or higher, operator 0.31.0 or higher is required, which the dev branch now has 0.32.0. This is because of breaking changes that thanos made requiring cluster communication.

## Instructions

1. Currently you will need to manually add a thanos objstore configmap or secret to the cattle-prometheus namespace. 

Documentation for the format can be found here https://github.com/thanos-io/thanos/blob/master/docs/storage.md

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: thanos-objstore-config
  namespace: cattle-prometheus

data:
  thanos.yml: |-
    type: S3
    config:
      bucket: thanos
      endpoint: minio.minio.svc.cluster.local:9000
      encrypt_sse: false
      access_key: accesskey
      secret_key: secretkey
      region: us-east-1
      insecure: true
      signature_version2: false
```

2. You can then add the following values to the monitoring deployment as yaml or fields

Fields
```
prometheus.thanos.baseImage=improbable/thanos
prometheus.thanos.version=v0.5.0
prometheus.thanos.objectStorageConfig.key=thanos.yml
prometheus.thanos.objectStorageConfig.name=thanos-objstore-config
```

YAML
```
prometheus:
  thanos:
    baseImage: improbable/thanos
    version: v0.5.0
    objectStorageConfig:
      key: thanos.yml
      name: thanos-objstore-config
```

Given these values added, the change in this PR simply passes the values through to the operator.
