### PR TITLE
Feature: thanos support

### DIFF
--- a/charts/rancher-monitoring/v0.0.7/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.7/charts/prometheus/templates/prometheus.yaml
@@ -26,7 +26,7 @@ spec:
     image: {{ template "system_default_registry" . }}{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}
     ports:
     - containerPort: 8080
-      name: http
+      name: nginx-http
       protocol: TCP
     {{- if and .Values.resources .Values.resources.proxy }}
     resources:
@@ -107,6 +107,14 @@ spec:
 {{- range $key, $value := .Values.externalLabels}}
     {{ $key }}: {{ $value | quote }}
 {{- end }}
+{{- end }}
+{{- if .Values.thanos.enabled }}
+  thanos: 
+    baseImage: {{ template "system_default_registry" . }}{{ .Values.image.thanos.repository }}
+    version: {{ .Values.image.thanos.tag }}
+    objectStorageConfig:
+      key: thanos.yaml
+      name: {{ template "app.thanos.fullname" . }}
 {{- end }}
   nodeSelector:
 {{- include "linux-node-selector" . | nindent 4 }}

--- a/charts/rancher-monitoring/v0.0.7/charts/prometheus/templates/secrets.yaml
+++ b/charts/rancher-monitoring/v0.0.7/charts/prometheus/templates/secrets.yaml
@@ -41,4 +41,4 @@ metadata:
 stringData:
   thanos.yaml: |-
 {{ toYaml .Values.thanos.objectConfig | indent 6 }}
-{{-end }}
+{{- end }}

--- a/charts/rancher-monitoring/v0.0.7/charts/prometheus/templates/secrets.yaml
+++ b/charts/rancher-monitoring/v0.0.7/charts/prometheus/templates/secrets.yaml
@@ -26,3 +26,19 @@ metadata:
 stringData:
   additional-alertmanager-configs.yaml: {{ template "additional-alertmanager-configs.yaml" . }}
 {{- end }}
+
+{{- if .Values.thanos.enabled }} 
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "app.thanos.fullname" . }}
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+stringData:
+  thanos.yaml: |-
+{{ toYaml .Values.thanos.objectConfig | indent 6 }}
+{{-end }}

--- a/charts/rancher-monitoring/v0.0.7/charts/prometheus/templates/service.yaml
+++ b/charts/rancher-monitoring/v0.0.7/charts/prometheus/templates/service.yaml
@@ -16,6 +16,34 @@ spec:
     chart: {{ template "app.version" . }}
     release: {{ .Release.Name }}
   ports:
-    - name: http
+    - name: nginx-http
       port: 80
-      targetPort: http
+      targetPort: nginx-http
+
+{{- if .Values.thanos.enabled }} 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: access-thanos
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    kubernetes.io/cluster-service: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: ClientIP
+  selector:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    release: {{ .Release.Name }}
+  ports:
+    - name: thanos-grpc
+      port: 10901
+      targetPort: 10901
+    - name: thanos-http
+      port: 10902
+      targetPort: 10902
+{{- end }}

--- a/charts/rancher-monitoring/v0.0.7/charts/prometheus/values.yaml
+++ b/charts/rancher-monitoring/v0.0.7/charts/prometheus/values.yaml
@@ -75,3 +75,9 @@ additionalAlertManagerConfigs: []
 istioMonitoring:
   enabled: true
   namespace: istio-system
+
+thanos:
+  enabled: false
+  ## ObjectStoreConfig
+  ## Ref: https://github.com/thanos-io/thanos/blob/master/docs/storage.md
+  objectConfig: {}

--- a/charts/rancher-monitoring/v0.0.7/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/v0.0.7/templates/_helpers.tpl
@@ -56,6 +56,10 @@
 {{- printf "%s-%s-cleanup" $name .Release.Name -}}
 {{- end -}}
 
+{{- define "app.thanos.fullname" -}}
+{{- $name := include "app.name" . -}}
+{{- printf "%s-%s-thanos" $name .Release.Name -}}
+{{- end -}}
 
 {{- define "kube_version" -}}
 {{- printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor -}}

--- a/charts/rancher-monitoring/v0.0.7/values.yaml
+++ b/charts/rancher-monitoring/v0.0.7/values.yaml
@@ -317,6 +317,9 @@ prometheus:
     proxy:
       repository: rancher/nginx
       tag: 1.17.4-alpine
+    thanos:
+      repository: thanosio/thanos
+      tag: v0.9.0
   nodeSelectors: []
   resources:
     core:
@@ -371,6 +374,8 @@ prometheus:
     clusterDisplayName: ""
   cluster:
     alertManagerNamespace: ""
+  thanos:
+    enabled: false
 
 global:
   systemDefaultRegistry: ""

--- a/charts/rancher-monitoring/v0.0.7/values.yaml
+++ b/charts/rancher-monitoring/v0.0.7/values.yaml
@@ -318,7 +318,7 @@ prometheus:
       repository: rancher/nginx
       tag: 1.17.4-alpine
     thanos:
-      repository: thanosio/thanos
+      repository: rancher/thanos
       tag: v0.9.0
   nodeSelectors: []
   resources:


### PR DESCRIPTION
This allows a power user to enable thanos in the prometheus definition for the operator to deploy properly.

## Important

This does not implement thanos or solve how to route this data to thanos, this simply provides the ability to tell the prometheus operator to deploy the thanos sidecar so that it CAN be harvested with the appropriate setup.

## Changes

1. Had to rename http to `nginx-http` to prevent a conflict in the service discovery and port discovery because the prometheus operator does things a certain way.

## Overview

To enable thanos there's new values supported by the rancher-monitoring chart

```
thanos:
  enabled: true
```

You can configure the object storage yaml by putting [valid storage yaml](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) for the property `objectConfig` 

**Note:** I named it `objectConfig` to not confuse it with `objectStorageConfig` which has a different set of properties required by the prometheus operator.

If thanos is enabled, the prometheus chart will now create a config map for the thanos config object storage.

```
thanos:
  enabled: true
  objectConfig:
    type: S3
    config:
      bucket: thanos
      region: us-east-1
      endpoint: minio.minio.svc.cluster.local:9000
      signature_version2: false
      insecure: true
      access_key: example
      secret_key: example
```

This adds the thanos image to the `prometheus` values so it can be set and changed by 

```
prometheus:
  image:
   thanos:
     repository: improbable/thanos
     tag: v0.6.0
```

## How To Use

Because the UI does not allow you to also modify by YAML you have to provide the thanos answers via the form.

```
prometheus.thanos.enabled=true
prometheus.thanos.objectConfig.type=S3
prometheus.thanos.objectConfig.config.bucket=thanos
prometheus.thanos.objectConfig.config.region=us-east-1
prometheus.thanos.objectConfig.config.endpoint=minio.minio.svc.cluster.local:9000
prometheus.thanos.objectConfig.config.signature_version2=false
prometheus.thanos.objectConfig.config.insecure=true
prometheus.thanos.objectConfig.config.access_key=example
prometheus.thanos.objectConfig.config.secret_key=example
```
