### PR TITLE
Distinguish Windows images

### DIFF
--- a/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-windows/values.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-windows/values.yaml
@@ -2,6 +2,7 @@ nameOverride: fluentd
 labels: {}
 
 image:
+  os: windows
   repository: rancher/fluentd
   tag: v0.1.16
   pullPolicy: IfNotPresent
@@ -44,6 +45,7 @@ service:
 configmapReload:
   name: reloader
   image:
+    os: windows
     repository: rancher/configmap-reload
     tag: v0.3.0-rancher2
     pullPolicy: IfNotPresent

--- a/charts/rancher-monitoring/v0.0.4/values.yaml
+++ b/charts/rancher-monitoring/v0.0.4/values.yaml
@@ -170,6 +170,7 @@ exporter-node-windows:
   endpoints: []
   nodeSelectors: []
   image:
+    os: windows
     repository: rancher/wmi_exporter-package
     tag: v0.0.2
   ports:


### PR DESCRIPTION
When we scan the system charts, there is no way to find out if there are some Windows images for it. So we would like to add a new field to indicate the image is used in Windows worker.

**Problem:**
Could not distinguish Windows images from `values.yaml`

**Solution:**
- Add a new field `os` below field `image`
- Must indicate `os: windows` if the image is using in Windows worker

**Issue:**
https://github.com/rancher/rancher/issues/22463