### PR TITLE
Fix monitoring upgrade do not update crds

### DIFF
--- a/charts/rancher-monitoring/v0.0.4/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.0.4/charts/operator-init/templates/job-install-crds.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "app.fullname" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   ttlSecondsAfterFinished: 100


### PR DESCRIPTION
**Problem:**
Error from operator.
```
E0914 02:59:39.410560 1 reflector.go:125] github.com/coreos/prometheus-operator/pkg/prometheus/operator.go:450: Failed to list *v1.PodMonitor: the server could not find the requested resource (get podmonitors.monitoring.coreos.com)
```

**Solution:**
add post-upgrade hook to ensure crd job exected on helm upgrade.


**Related Issue:**
https://github.com/rancher/rancher/issues/22862

