### PR TITLE
Upgrade rancher fluentd image version to v0.1.17

### DIFF
--- a/charts/rancher-logging/0.1.2/charts/fluentd-tester/values.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd-tester/values.yaml
@@ -2,7 +2,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.16
+  tag: v0.1.17
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-linux/values.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-linux/values.yaml
@@ -3,7 +3,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.16
+  tag: v0.1.17
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-windows/values.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-windows/values.yaml
@@ -4,7 +4,7 @@ labels: {}
 image:
   os: windows
   repository: rancher/fluentd
-  tag: v0.1.16
+  tag: v0.1.17
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
Problem:
Fluentd will start creating hundreds of thousands of 0 byte buffer log files when the partition it is on runs out of space.
https://github.com/fluent/fluentd/issues/2593

Solution:
Upgrade gems version and release rancher/fluentd:v0.1.17

Issue:
https://github.com/rancher/rancher/issues/22689