### PR TITLE
Fix project level monitoring can not upgrade

### DIFF
--- a/charts/rancher-monitoring/v0.0.4/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.4/charts/prometheus/templates/prometheus.yaml
@@ -80,9 +80,7 @@ spec:
   listenLocal: true
 {{- end }}
   podMetadata:
-    {{- if .Release.IsInstall }}
     creationTimestamp: {{ now | date "2006-01-02T15:04:05Z" | quote }}
-    {{- end }}
     labels:
       app: {{ template "app.name" . }}
       chart: {{ template "app.version" . }}


### PR DESCRIPTION
**Problem:**
Project level Prometheus can't be upgraded due to `spec.podMetadata.creationTimestamp in the body must be of type string: "null"`

**Solution:**
Remove `{{- if .Release.IsInstall }}` check of `creationTimestamp` since this is required for both update and create.


**Related Issue:**
https://github.com/rancher/rancher/issues/22915