### PR TITLE
Enable securityContext for exporter-kube-state and operator-init

### DIFF
--- a/charts/rancher-monitoring/v0.0.4/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.0.4/charts/operator-init/templates/job-install-crds.yaml
@@ -16,6 +16,10 @@ spec:
       tolerations:
 {{- include "linux-node-tolerations" . | nindent 8}}
       serviceAccountName: {{ template "app.fullname" . }}
+      securityContext:
+        runAsUser: 65534
+        runAsNonRoot: true
+        fsGroup: 65534
       containers:
       - name: operator-init-crds
         image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/charts/rancher-monitoring/v0.0.4/values.yaml
+++ b/charts/rancher-monitoring/v0.0.4/values.yaml
@@ -198,7 +198,10 @@ exporter-kube-state:
   ## Already exist ServiceAccount
   ##
   serviceAccountName: ""
-  securityContext: {}
+  securityContext:
+    runAsUser: 65534
+    runAsNonRoot: true
+    fsGroup: 65534
 
 alertmanager:
   enabled: false


### PR DESCRIPTION
Update securityContext for monitoring containers. Allows monitoring to run when Rancher hardening rules are applied.

https://github.com/rancher/rancher/issues/20884
