### PR TITLE
Relabel __meta_kubernetes_pod_controller_name to created_by

### DIFF
--- a/charts/rancher-monitoring/v0.0.4/charts/prometheus/additionals/c-scrape_prometheus_io.yaml
+++ b/charts/rancher-monitoring/v0.0.4/charts/prometheus/additionals/c-scrape_prometheus_io.yaml
@@ -55,6 +55,6 @@
     replacement: $1
   - source_labels: [__meta_kubernetes_pod_controller_name]
     action: replace
-    target_label: created_by_kind
+    target_label: created_by
     regex: (.+)
     replacement: $1


### PR DESCRIPTION
Currently, both __meta_kubernetes_pod_controller_kind and __meta_kubernetes_pod_controller_name end up being mapped to created_by_kind. I guess that is a mistake, since the data from __meta_kubernetes_pod_controller_kind is lost.