### PR TITLE
Respect namespace label from the nginx ingres controller

### DIFF
--- a/charts/rancher-monitoring/v0.0.4/charts/prometheus/additionals/c-scrape_prometheus_io.yaml
+++ b/charts/rancher-monitoring/v0.0.4/charts/prometheus/additionals/c-scrape_prometheus_io.yaml
@@ -58,3 +58,11 @@
     target_label: created_by_kind
     regex: (.+)
     replacement: $1
+  metric_relabel_configs:
+  - source_labels: [controller_namespace, exported_namespace]
+    action: replace
+    target_label: namespace
+    regex: ingress-nginx;(.+)
+    replacement: $1
+  - regex: exported_namespace
+    action: labeldrop


### PR DESCRIPTION
To allow project monitoring to access nginx ingress metrics, the correct value needs to be in the namespace field. Currently, it stored in exported_namespace, because the namespace label is already defined.