### PR TITLE
Fix nginx user permissions in nginx-alpine image

### DIFF
--- a/charts/rancher-monitoring/v0.0.5/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.5/charts/grafana/templates/deployment.yaml
@@ -106,11 +106,13 @@ spec:
         volumeMounts:
         - mountPath: /nginx/
           name: grafana-nginx
+        - mountPath: /var/cache/nginx
+          name: nginx-home
         {{- if and .Values.resources .Values.resources.proxy }}
         resources:
 {{ toYaml .Values.resources.proxy | indent 10 }}
         securityContext:
-          runAsUser: 100
+          runAsUser: 101
           runAsGroup: 101
         {{- end }}
       nodeSelector:
@@ -167,3 +169,5 @@ spec:
       - name: grafana-provisionings
         configMap:
           name: {{ template "app.provisionings.fullname" . }}
+      - name: nginx-home
+        emptyDir: {}

--- a/charts/rancher-monitoring/v0.0.5/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.5/charts/prometheus/templates/prometheus.yaml
@@ -33,11 +33,13 @@ spec:
 {{ toYaml .Values.resources.proxy | indent 6 }}
     {{- end }}
     securityContext:
-      runAsUser: 100
+      runAsUser: 101
       runAsGroup: 101
     volumeMounts:
     - mountPath: /nginx
       name: configmap-{{ template "app.nginx.fullname" . }}
+    - mountPath: /var/cache/nginx
+      name: nginx-home
 {{- if eq .Values.level "cluster" }}
   - name: prometheus-agent
     command:
@@ -169,6 +171,9 @@ spec:
             storage: {{ .Values.persistence.size | quote }}
 {{- end }}
 {{- end }}
+  volumes:
+  - name: nginx-home
+    emptyDir: {}
   version: "{{ .Values.image.tag }}"
   affinity:
     podAntiAffinity:


### PR DESCRIPTION
Address issues: 
https://github.com/rancher/rancher/issues/23573

Problem:
Fails to run nginx proxies, because user home directory is not owned by nginx user inside newer nginx-alpine images

Solution:
Mount emptyDir to the user home directory(/var/cache/nginx) so that it
is writable by the nginx user.
Also update UID from 100 to 101 to be consistent with upstream changes(https://github.com/nginxinc/docker-nginx/issues/218)