### PR TITLE
Add creationTimestamp to prometheus storage metadata

### DIFF
--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus/templates/prometheus.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus/templates/prometheus.yaml
@@ -156,6 +156,7 @@ spec:
       {{- if .Values.persistence.name }}
       metadata:
         name: {{ .Values.persistence.name }}
+        creationTimestamp: {{ now | date "2006-01-02T15:04:05Z" | quote }}
       {{- end }}
       spec:
 {{- if .Values.storageSpec }}


### PR DESCRIPTION
**Problem:**
`spec.storage.volumeClaimTemplate.metadata.creationTimestamp` in body must be of type string: "null"' error upgrading cluster-monitoring 0.0.3 with persistent prometheus storage to cluster-monitoring 0.0.5

**Solution:**
Add creationTimestamp to prometheus storage metadata

**Related Issue:**
https://github.com/rancher/rancher/issues/23857