### PR TITLE
Bump coreos-kube-state-metrics version

### DIFF
--- a/charts/rancher-monitoring/v0.0.6/charts/exporter-kube-state/templates/rbac.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/exporter-kube-state/templates/rbac.yaml
@@ -67,6 +67,28 @@ rules:
   verbs: 
   - "list"
   - "watch"
+- apiGroups: 
+  - "extensions"
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - "list"
+  - "watch"
+- apiGroups: 
+  - "certificates.k8s.io"
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - "list"
+  - "watch"
+- apiGroups: 
+  - "storage.k8s.io"
+  resources:
+    - storageclasses
+  verbs: 
+  - "list"
+  - "watch"
 
 ---
 apiVersion: v1

--- a/charts/rancher-monitoring/v0.0.6/values.yaml
+++ b/charts/rancher-monitoring/v0.0.6/values.yaml
@@ -186,7 +186,7 @@ exporter-kube-state:
   apiGroup: "monitoring.coreos.com"
   image:
     repository: rancher/coreos-kube-state-metrics
-    tag: v1.5.0
+    tag: v1.8.0
   nodeSelectors: []
   resources:
     limits:


### PR DESCRIPTION
Problem:

There are some error logs in coreos-kube-state-metrics pod for monitoring

Solution:

Bump coreos-kube-state-metrics version to support k8s 1.16

Issue:

https://github.com/rancher/rancher/issues/23556