### PR TITLE
[WIP] Support prometheus adapter

### DIFF
--- a/charts/rancher-monitoring/v0.0.6/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/grafana/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
         {{- end }}
         {{- end }}
     {{- if .Values.enabledRBAC }}
-      serviceAccountName: {{ default (default (include "app.fullname" .) .Values.serviceAccountName) .Values.serviceAccountNameOverride }}
+      serviceAccountName: {{ default (include "app.fullname" .) .Values.serviceAccountName }}
     {{- end }}
       tolerations:
 {{- include "linux-node-tolerations" . | nindent 8 }}

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/Chart.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: Creates Prometheus-adapter instance for Kubernetes which maintaining by Rancher 2.
+engine: gotpl
+maintainers:
+- name: thxCode
+  email: frank@rancher.com
+name: prometheus-adapter
+version: 0.0.1

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/files/aggregator-rbac.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/files/aggregator-rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ default (include "app.fullname" .) .Values.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ default (include "app.fullname" .) .Values.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/aggregator-rbac-mgmt-rbac.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/aggregator-rbac-mgmt-rbac.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "app.fullname" . }}-aggregator-rbac-mgmt
+imagePullSecrets: 
+{{ toYaml .Values.image.pullSecrets | indent 2 }}
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-aggregator-rbac-mgmt
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - "tokenreviews"
+  verbs:
+  - "create"
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - "subjectaccessreviews"
+  verbs:
+  - "create"
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-aggregator-rbac-mgmt
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-aggregator-rbac-mgmt
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "app.fullname" . }}-aggregator-rbac-mgmt
+    namespace: {{ .Release.Namespace }}
+

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/aggregator-rbac-mgmt.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/aggregator-rbac-mgmt.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "app.fullname" . }}-aggregator-rbac
+data:
+  rbac.yaml: |-
+{{- $root := . -}}
+{{ range $path, $bytes := .Files.Glob "files/aggregator-rbac.yaml" }}
+{{ tpl ($bytes | toString) $root | printf "%s" | indent 4 }}
+{{ end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "app.fullname" . }}-aggregator-rbac-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "-5"
+spec:
+  ttlSecondsAfterFinished: 30
+  backoffLimit: 3
+  template:
+    spec:
+      serviceAccountName: {{ template "app.fullname" . }}-aggregator-rbac-mgmt
+      containers:
+      - name: aggregator-rbac-install
+        image: {{ template "system_default_registry" . }}{{ .Values.image.kubectl.repository }}:{{ .Values.image.kubectl.tag }}
+        volumeMounts:
+        - name: aggregator-rbac
+          mountPath: /etc/prometheus-adapter/aggregator-rbac/
+          readOnly: true
+        command: 
+        - kubectl
+        - apply
+        - -f
+        - /etc/prometheus-adapter/aggregator-rbac/rbac.yaml
+      volumes:
+      - name: aggregator-rbac
+        configMap:
+          name: {{ template "app.fullname" . }}-aggregator-rbac
+      restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "app.fullname" . }}-aggregator-rbac-uninstall
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-delete-policy": "hook-succeeded, before-hook-creation, hook-failed"
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ template "app.fullname" . }}-aggregator-rbac-mgmt
+      containers:
+      - name: aggregator-rbac-uninstall
+        image: {{ template "system_default_registry" . }}{{ .Values.image.kubectl.repository }}:{{ .Values.image.kubectl.tag }}
+        volumeMounts:
+        - name: aggregator-rbac
+          mountPath: /etc/prometheus-adapter/aggregator-rbac/
+          readOnly: true
+        command: 
+        - kubectl
+        - delete
+        - -f
+        - /etc/prometheus-adapter/aggregator-rbac/rbac.yaml
+      volumes:
+      - name: aggregator-rbac
+        configMap:
+          name: {{ template "app.fullname" . }}-aggregator-rbac
+      restartPolicy: OnFailure
+
+

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/apiservices.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/apiservices.yaml
@@ -1,0 +1,79 @@
+apiVersion: {{ template "apiregistration_api_version" . }}
+kind: APIService
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  service:
+    namespace: {{ .Release.Namespace }}
+    name: access-prometheus-adapter
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100
+  {{ if .Values.tls.enabled -}}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  insecureSkipTLSVerify: false
+  {{- else }}
+  insecureSkipTLSVerify: true
+  {{- end }}
+
+
+{{- if not (.Capabilities.APIVersions.Has "external.metrics.k8s.io/v1beta1") }}
+---
+apiVersion: {{ template "apiregistration_api_version" . }}
+kind: APIService
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  service:
+    namespace: {{ .Release.Namespace }}
+    name: access-prometheus-adapter
+  group: external.metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100
+  {{ if .Values.tls.enabled -}}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  insecureSkipTLSVerify: false
+  {{- else }}
+  insecureSkipTLSVerify: true
+  {{- end }}
+{{- end }}
+
+
+{{- if not (.Capabilities.APIVersions.Has "metrics.k8s.io/v1beta1") }}
+---
+apiVersion: {{ template "apiregistration_api_version" . }}
+kind: APIService
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    namespace: {{ .Release.Namespace }}
+    name: access-prometheus-adapter
+  group: metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100
+  {{ if .Values.tls.enabled -}}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  insecureSkipTLSVerify: false
+  {{- else }}
+  insecureSkipTLSVerify: true
+  {{- end }}
+{{- end }}

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/configmap.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/configmap.yaml
@@ -1,0 +1,25 @@
+{{- $rules := merge .Values.rules .Values.defaultRules -}}
+
+{{- if not $rules.previousConfigMapName -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "app.fullname" . }}
+data:
+  config.yaml: |
+    rules:
+{{ toYaml $rules.customs | indent 4 }}
+{{- if $rules.externals }}
+    externalRules:
+{{ toYaml $rules.externals | indent 4 }}
+{{- end -}}
+{{- if $rules.resources }}
+    resourceRules:
+{{ toYaml $rules.resources | indent 6 }}
+{{- end -}}
+{{- end }}

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: {{ template "deployment_api_version" . }}
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "app.fullname" . }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "app.name" . }}
+      chart: {{ template "app.version" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "app.name" . }}
+        chart: {{ template "app.version" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.enabledRBAC }}
+      serviceAccountName:  {{ default (include "app.fullname" .) .Values.serviceAccountName }}
+      {{- end }}
+      containers:
+      - name: adapter
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        args:
+        - /adapter
+        - --secure-port=6443
+        {{- if .Values.tls.enable }}
+        - --tls-cert-file=/var/run/serving-cert/tls.crt
+        - --tls-private-key-file=/var/run/serving-cert/tls.key
+        {{- end }}
+        - --cert-dir=/tmp/cert
+        - --logtostderr=true
+        - --v={{ .Values.logLevel }}
+        - --config=/etc/adapter/config.yaml
+        - --prometheus-url={{ default "http://prometheus-operated:9090" .Values.prometheusURL }}
+        - --prometheus-auth-incluster
+        - --prometheus-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - --metrics-relist-interval={{ .Values.prometheusMetricsRelistInterval }}
+        - --metrics-max-age={{ .Values.prometheusMetricsMaxAge }}
+        ports:
+        - containerPort: 6443
+          name: https
+        livenessProbe:
+{{ merge .Values.livenessProbe .Values.defaultLivenessProbe | toYaml | indent 10 }}
+        readinessProbe:
+{{ merge .Values.readinessProbe .Values.defaultReadinessProbe | toYaml | indent 10 }}
+        {{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        {{- end }}
+        {{- if .Values.securityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: adapter-config
+          mountPath: /etc/adapter/
+          readOnly: true
+        {{- if .Values.tls.enabled }}
+        - name: adapter-cert
+          mountPath: /var/run/serving-cert
+          readOnly: true
+        {{- end }}
+        - name: adapter-tmp
+          mountPath: /tmp
+      nodeSelector:
+{{- include "linux-node-selector" . | nindent 8 }}
+        {{- range .Values.nodeSelectors }}
+        {{- $pair := regexSplit "=" . 2 }}
+        {{- if eq 2 (len $pair) }}
+        {{ (index $pair 0) }}: {{ (index $pair 1) }}
+        {{- else }}
+        {{ (index $pair 0) }}: ""
+        {{- end }}
+        {{- end }}
+      tolerations:
+{{- include "linux-node-tolerations" . | nindent 8 }}
+      {{- if .Values.tolerations }}
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      volumes:
+      - name: adapter-config
+        configMap:
+          name: {{ default (include "app.fullname" .) .Values.rules.previousConfigMapName }}
+      {{- if .Values.tls.enabled }}
+      - name: adapter-cert
+        secret:
+          secretName: {{ template "app.fullname" . }}
+      {{- end }}
+      - name: adapter-tmp
+        emptyDir: {}

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/rbac.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/rbac.yaml
@@ -1,0 +1,151 @@
+{{- if and .Values.enabledRBAC (not .Values.serviceAccountName) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "app.fullname" . }}
+imagePullSecrets: 
+{{ toYaml .Values.image.pullSecrets | indent 2 }}
+{{- end }}
+
+# custom metrics
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-custom-metrics
+rules:
+# read Kubernetes resources
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+# full-control custom metrics
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-hpa-controller-custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-custom-metrics
+subjects:
+- kind: ServiceAccount
+  name: {{ default (include "app.fullname" .) .Values.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+
+
+# external metrics
+{{- if not (.Capabilities.APIVersions.Has "external.metrics.k8s.io/v1beta1") }}
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-external-metrics
+rules:
+# read-only external metrics (hpa)
+- apiGroups:
+  - "external.metrics.k8s.io"
+  resources:
+  - "*"
+  verbs:
+  - list
+  - get
+  - watch
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-hpa-controller-external-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-external-metrics
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+{{- end }}
+
+
+# resource metrics
+{{- if not (.Capabilities.APIVersions.Has "metrics.k8s.io/v1beta1") }}
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-metrics
+rules:
+# read-only pods & nodes
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: {{ template "rbac_api_version" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-hpa-controller-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "app.fullname" . }}-{{ .Release.Namespace }}-metrics
+subjects:
+- kind: ServiceAccount
+  name: {{ default (include "app.fullname" .) .Values.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/secret.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.tls.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "app.fullname" . }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ b64enc .Values.tls.cert }}
+  tls.key: {{ b64enc .Values.tls.key }}
+{{- end -}}

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/service.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: access-prometheus-adapter
+spec:
+  type: ClusterIP
+  sessionAffinity: ClientIP
+  selector:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    release: {{ .Release.Name }}
+  ports:
+  - name: https
+    port: 443
+    targetPort: https

--- a/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/values.yaml
+++ b/charts/rancher-monitoring/v0.0.6/charts/prometheus-adapter/values.yaml
@@ -1,0 +1,139 @@
+enabledRBAC: true
+
+## Tolerations for use with node taints
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+  #  - key: "key"
+  #    operator: "Equal"
+  #    value: "value"
+  #    effect: "NoSchedule"
+
+logLevel: 2
+replicas: 1
+
+## Default liveness probe
+##
+defaultLivenessProbe:
+  initialDelaySeconds: 60
+  failureThreshold: 6
+  httpGet:
+    path: /healthz
+    port: https
+    scheme: HTTPS
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 10
+
+## Default readiness probe
+##
+defaultReadinessProbe:
+  initialDelaySeconds: 30
+  failureThreshold: 10
+  httpGet:
+    path: /healthz
+    port: https
+    scheme: HTTPS
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 10
+
+## Default rules
+##
+defaultRules:
+  previousConfigMapName: ""
+  customs:
+  # this rule matches cumulative cAdvisor metrics
+  - seriesQuery: '{__name__=~"^container_.*",namespace!="",pod_name!="",container_name!="POD"}'
+    # skip specifying generic resource<->label mappings, and just
+    # attach only pod and namespace resources by mapping label names to group-resources
+    resources:
+      overrides:
+        namespace:
+          resource: namespace
+        pod_name:
+          resource: pod
+    # change name
+    name:
+      matches: ^container_(.*)_total$
+      as: "container_$1"
+    metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[5m])) by (<<.GroupBy>>)
+  # this rule matches cAdvisor metrics that aren't cumulative
+  - seriesQuery: '{__name__=~"^container_.*",namespace!="",pod_name!="",container_name!="POD"}'
+    seriesFilters:
+    - isNot: .*_total$
+    - isNot: .*_depth$
+    - isNot: .*_bucket$
+    - isNot: .*_sum$
+    - isNot: .*_summary$
+    - isNot: .*_seconds_count$
+    resources:
+      overrides:
+        namespace:
+          resource: namespace
+        pod_name:
+          resource: pod
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}) by (<<.GroupBy>>)
+  # this rule matches non-cAdvisor metrics
+  - seriesQuery: '{__name__!~"(^(container_|nginx_ingress_|go_gc_|scrape_).*|up)",namespace!="",job!~"(^expose-.*-metrics$|kubernetes)"}'
+    resources:
+      overrides:
+        namespace:
+          resource: namespace
+        pod:
+          resource: pod
+    name:
+      matches: ^(.*)_total$
+      as: "$1"
+    metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
+  # this rule matches non-cAdvisor metrics that aren't cumulative
+  - seriesQuery: '{__name__!~"(^(container_|nginx_ingress_|go_gc_|scrape_).*|up)",namespace!="",job!~"(^expose-.*-metrics$|kubernetes)"}'
+    seriesFilters:
+    - isNot: .*_total$
+    - isNot: .*_depth$
+    - isNot: .*_bucket$
+    - isNot: .*_sum$
+    - isNot: .*_summary$
+    - isNot: .*_seconds_count$
+    resources:
+      overrides:
+        namespace:
+          resource: namespace
+        pod:
+          resource: pod
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+
+  externals: []
+# - seriesQuery: '{__name__=~"^some_metric_count$"}'
+#   resources:
+#     template: <<.Resource>>
+#   name:
+#     matches: ""
+#     as: "my_external_metric"
+#   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+  resources: {}
+#   cpu:
+#     containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[3m])) by (<<.GroupBy>>)
+#     nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[3m])) by (<<.GroupBy>>)
+#     resources:
+#       overrides:
+#         instance:
+#           resource: node
+#         namespace:
+#           resource: namespace
+#         pod_name:
+#           resource: pod
+#     containerLabel: container_name
+#   memory:
+#     containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+#     nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+#     resources:
+#       overrides:
+#         instance:
+#           resource: node
+#         namespace:
+#           resource: namespace
+#         pod_name:
+#           resource: pod
+#     containerLabel: container_name
+#   window: 3m

--- a/charts/rancher-monitoring/v0.0.6/requirements.yaml
+++ b/charts/rancher-monitoring/v0.0.6/requirements.yaml
@@ -59,6 +59,11 @@ dependencies:
     condition: grafana.enabled
     repository: "file://./charts/grafana/"
 
+  - name: prometheus-adapter
+    version: 0.0.1
+    condition: prometheus-adapter.enabled
+    repository: "file://./charts/prometheus-adapter/"
+
   - name: prometheus
     version: 0.0.1
     condition: prometheus.enabled

--- a/charts/rancher-monitoring/v0.0.6/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/v0.0.6/templates/_helpers.tpl
@@ -119,6 +119,15 @@
 {{- end -}}
 
 
+{{- define "apiregistration_api_version" -}}
+{{- if .Capabilities.APIVersions.Has "apiregistration.k8s.io/v1" -}}
+{{- "apiregistration.k8s.io/v1" -}}
+{{- else -}}
+{{- "apiregistration.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+
 {{- define "system_default_registry" -}}
 {{- if .Values.global.systemDefaultRegistry -}}
 {{- printf "%s/" .Values.global.systemDefaultRegistry -}}

--- a/charts/rancher-monitoring/v0.0.6/values.yaml
+++ b/charts/rancher-monitoring/v0.0.6/values.yaml
@@ -293,6 +293,52 @@ grafana:
   serviceAccountName: ""
   prometheusDatasourceURL: "http://prometheus-operated:9090"
 
+prometheus-adapter:
+  enabled: false
+  image:
+    repository: directxman12/k8s-prometheus-adapter-amd64
+    tag: v0.5.0
+    kubectl:
+      repository: rancher/istio-kubectl
+      tag: 1.3.3
+  nodeSelectors: []
+  resources: 
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  tls:
+    enabled: false
+    ca: |-
+        # Public CA file content that signed the APIService
+    key: |-
+        # Private key content of the APIService
+    cert: |-
+        # Public key content of the APIService
+  rules:
+    previousConfigMapName: ""
+    customs:   []
+    externals: []
+    resources: {}
+  ## Already exist ServiceAccount
+  ##
+  serviceAccountName: ""
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: 
+      - "all"
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10001
+  prometheusURL: ""
+  prometheusMetricsRelistInterval: 1m
+  prometheusMetricsMaxAge: 5m
+  livenessProbe: {}
+  readinessProbe: {}
+
 prometheus:
   enabled: false
   level: cluster


### PR DESCRIPTION
Support to deploy prometheus-adapter:

**Implement (differences from helm/chart):**
- Modify all cumulative metrics to ratio representation:
    + `.*_total` -> `.*`
    + `.*_seconds_total` > `.*_seconds`
- Filter out useless metrics:
    + `job=~"(^expose-.*-metrics|kubernetes)"`, scraped metrics of system components
    + `{__name__!~"(^(nginx_ingree_|go_gc_|scrape_).*|up)"}`
    + histogram/summary metrics

**Usage:**
``` json
prometheus-adapter:
  enabled: false                        // turn on/off
  image:
    repository: directxman12/k8s-prometheus-adapter-amd64
    tag: v0.5.0
    kubectl:
      repository: rancher/istio-kubectl
      tag: 1.3.3
  ...
  rules:
    previousConfigMapName: ""           // customization if needed
    ...
  prometheusMetricsRelistInterval: 1m   // interval at which to re-list the set of all available metrics from Prometheus
  prometheusMetricsMaxAge: 5m          // period for which to query the set of available metrics from Prometheus
```

**Limited:**
- https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/104 indicates that we could not have an auto-refresh prometheus-adapter solution at this time.

**TODO:**
- [ ] We need to push `directxman12/k8s-prometheus-adapter-amd64:v0.5.0` to rancher Docker repo.

**Based PR:**
- https://github.com/rancher/rancher/pull/24121
