### PR TITLE
CIS fixes

### DIFF
--- a/charts/rancher-cis-benchmark/v0.0.1/templates/configmap.yaml
+++ b/charts/rancher-cis-benchmark/v0.0.1/templates/configmap.yaml
@@ -87,6 +87,10 @@ data:
         value: /tmp/results
       - name: CHROOT_DIR
         value: /node
+      {{- if .Values.overrideBenchmarkVersion }}
+      - name: OVERRIDE_BENCHMARK_VERSION
+        value: {{ .Values.overrideBenchmarkVersion }}
+      {{- end }}
       {{- if .Values.debugWorker }}
       - name: DEBUG
         value: "true"

--- a/charts/rancher-cis-benchmark/v0.0.1/templates/pod.yaml
+++ b/charts/rancher-cis-benchmark/v0.0.1/templates/pod.yaml
@@ -32,8 +32,10 @@ spec:
     - name: {{ .Chart.Name }}
       restartPolicy: Never
       env:
-        - name: SKIP
-          value: {{ .Values.skip }}
+        {{- if .Values.overrideBenchmarkVersion }}
+        - name: OVERRIDE_BENCHMARK_VERSION
+          value: {{ .Values.overrideBenchmarkVersion }}
+        {{- end }}
         - name: SONOBUOY_NS
           value: {{ .Release.Namespace }}
         - name: SONOBUOY_POD_NAME

--- a/charts/rancher-cis-benchmark/v0.0.1/values.yaml
+++ b/charts/rancher-cis-benchmark/v0.0.1/values.yaml
@@ -6,11 +6,12 @@ replicaCount: 1
 
 # if owner is specified, it's used for the name of the configmap for results
 owner: ""
-# skip is used specify which tests to skip
-skip: ""
 # skipConfigMapName is used to specify the name of cm where the skip info is stored
 # skip has higher precedence than what's specified in the configmap
 skipConfigMapName: ""
+# overrideBenchmarkVersion is used to override the default benchmark version used for
+# a particular k8s version
+overrideBenchmarkVersion: ""
 
 # when debug=true, the plugin pods sleep for the time specified
 debugMaster: false

--- a/charts/rancher-cis-benchmark/v0.0.1/values.yaml
+++ b/charts/rancher-cis-benchmark/v0.0.1/values.yaml
@@ -20,7 +20,7 @@ debugTime: "infinity"
 
 image:
   repository: rancher/security-scan
-  tag: v0.1.3
+  tag: v0.1.4
   pullPolicy: Always
 
 nameOverride: ""


### PR DESCRIPTION
- Add benchmark version field to the report (https://github.com/rancher/rancher/issues/24562)
- Add ability to override benchmark version (https://github.com/rancher/rancher/issues/24563)
- Add support to specify skip for different benchmark versions (https://github.com/rancher/rancher/issues/23905)
- Fixed failure when the configmap for skip is malformed (https://github.com/rancher/rancher/issues/24539)
- Fixed issue when skip from API is not working when empty (https://github.com/rancher/rancher/issues/24444)
- Fixed issue with mixed result not showing nodes (https://github.com/rancher/rancher/issues/24540, https://github.com/rancher/rancher/issues/24431)