### PR TITLE
Add upgrade hook to new istio CRD

### DIFF
--- a/charts/rancher-istio/1.4.300/templates/crd-14.yaml
+++ b/charts/rancher-istio/1.4.300/templates/crd-14.yaml
@@ -8,7 +8,7 @@ metadata:
     release: istio
   name: authorizationpolicies.security.istio.io
   annotations:
-    helm.sh/hook: crd-install
+    helm.sh/hook: crd-install,pre-upgrade
 spec:
   group: security.istio.io
   names:


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/25077

This PR specifically addresses that the `crd-install` hook doesn't work on helm upgrades. 