### PR TITLE
Fix route53 global dns providers

### DIFF
--- a/charts/rancher-external-dns/v0.0.3/templates/_helpers.tpl
+++ b/charts/rancher-external-dns/v0.0.3/templates/_helpers.tpl
@@ -42,7 +42,6 @@ aws_secret_access_key = {{ .Values.aws.secretKey }}
 role_arn = {{ .Values.aws.roleArn }}
 {{- end }}
 region = {{ .Values.aws.region }}
-source_profile = default
 {{ end }}
 
 {{- define "external-dns.alibabacloud-config" }}


### PR DESCRIPTION
This commit adds https://github.com/helm/charts/pull/19839 to our
rancher chart