### PR TITLE
[BUG] Can't activate fluentd configmapReload resource limit

### DIFF
--- a/charts/rancher-logging/0.0.1/charts/fluentd/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.0.1/charts/fluentd/templates/daemonset.yaml
@@ -133,7 +133,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/custom
             name: custom

--- a/charts/rancher-logging/0.1.1/charts/fluentd/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.1/charts/fluentd/templates/daemonset.yaml
@@ -133,7 +133,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/custom
             name: custom

--- a/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/custom
             name: custom

--- a/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.2/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
@@ -114,7 +114,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/precan
             name: config

--- a/charts/rancher-logging/0.1.3/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.3/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/custom
             name: custom

--- a/charts/rancher-logging/0.1.3/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.3/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
@@ -114,7 +114,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/precan
             name: config

--- a/charts/rancher-logging/0.1.4/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.4/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/custom
             name: custom

--- a/charts/rancher-logging/0.1.4/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.1.4/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
@@ -114,7 +114,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/precan
             name: config

--- a/charts/rancher-logging/0.2.0/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.2.0/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
@@ -136,7 +136,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/custom
             name: custom

--- a/charts/rancher-logging/0.2.0/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.2.0/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
@@ -114,7 +114,7 @@ spec:
           - --webhook-method=GET
           - --webhook-url=http://127.0.0.1:24444/api/config.reload
         resources:
-        {{ toYaml .Values.configmapReload.resources | indent 12 }}
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
         volumeMounts:
           - mountPath: /fluentd/etc/config/precan
             name: config


### PR DESCRIPTION
**Problem:**
```
fluentd:
  enabled: true
  fluentd-linux:
    configmapReload:
      resources:
        limits:
          cpu: "20m"
```

```
helm install --dry-run -f values.yaml rancher-logging2 ./charts/rancher-logging/0.1.4/
Error: YAML parse error on rancher-logging/charts/fluentd/charts/fluentd-linux/templates
/daemonset.yaml: error converting YAML to JSON: yaml: line 107: did not find expected key
```
**Fix:**
1. start the template from char 0
2. indent to 10, same as resourch at line 54

@deniseschannon Can this get a review? It is also wrong in the logging system-chart 0.1.5 just merged in #179 
