### PR TITLE
bump the backofflimit for k3s-upgrader jobs

### DIFF
--- a/charts/rancher-k3s-upgrader/v0.0.1/templates/configmap.yaml
+++ b/charts/rancher-k3s-upgrader/v0.0.1/templates/configmap.yaml
@@ -7,7 +7,7 @@ data:
   SYSTEM_UPGRADE_CONTROLLER_DEBUG: {{ .Values.systemUpgradeControllerDebug | default "false" | quote }}
   SYSTEM_UPGRADE_CONTROLLER_THREADS: {{ .Values.systemUpgradeControllerThreads | default "2" | quote }}
   SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: {{ .Values.systemUpgradeJobActiveDeadlineSeconds | default "900" | quote }}
-  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: {{ .Values.systemUpgradeJobBackoffLimit | default "2" | quote }}
+  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: {{ .Values.systemUpgradeJobBackoffLimit | default "6" | quote }}
   SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: {{ .Values.systemUpgradeJobImagePullPolicy | default "IfNotPresent" | quote }}
   SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: {{ .Values.systemUpgradeJobKubectlImage | default "rancher/kubectl:v1.17.0" | quote }}
   SYSTEM_UPGRADE_JOB_PRIVILEGED: {{ .Values.systemUpgradeJobPrivileged | default "true" | quote }}


### PR DESCRIPTION
Attempting to mitigate rancher/rancher#25882, a `BackoffLimit` of 6 for upgrade jobs matches the default imposed by the job controller.

