### PR TITLE
bump system-upgrade-controller to v0.4.0-rc1

### DIFF
--- a/charts/rancher-k3s-upgrader/v0.0.1/Chart.yaml
+++ b/charts/rancher-k3s-upgrader/v0.0.1/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/rancher/system-charts/charts/system-upgrade-controller
 sources:
   - "https://github.com/rancher/system-charts/charts/system-upgrade-controller"
 version: 0.1.0
-appVersion: v0.3.1
+appVersion: v0.4.0-rc1

--- a/charts/rancher-k3s-upgrader/v0.0.1/templates/configmap.yaml
+++ b/charts/rancher-k3s-upgrader/v0.0.1/templates/configmap.yaml
@@ -7,9 +7,10 @@ data:
   SYSTEM_UPGRADE_CONTROLLER_DEBUG: {{ .Values.systemUpgradeControllerDebug | default "false" | quote }}
   SYSTEM_UPGRADE_CONTROLLER_THREADS: {{ .Values.systemUpgradeControllerThreads | default "2" | quote }}
   SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: {{ .Values.systemUpgradeJobActiveDeadlineSeconds | default "900" | quote }}
-  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: {{ .Values.systemUpgradeJobBackoffLimit | default "6" | quote }}
+  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: {{ .Values.systemUpgradeJobBackoffLimit | default "99" | quote }}
   SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: {{ .Values.systemUpgradeJobImagePullPolicy | default "IfNotPresent" | quote }}
   SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: {{ .Values.systemUpgradeJobKubectlImage | default "rancher/kubectl:v1.17.0" | quote }}
   SYSTEM_UPGRADE_JOB_PRIVILEGED: {{ .Values.systemUpgradeJobPrivileged | default "true" | quote }}
+  SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: {{ .Values.systemUpgradeJobTTLSecondsAfterFinish | default "900" | quote }}
   SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL: {{ .Values.systemUpgradePlanRollingInterval | default "15m" | quote }}
 

--- a/charts/rancher-k3s-upgrader/v0.0.1/values.yaml
+++ b/charts/rancher-k3s-upgrader/v0.0.1/values.yaml
@@ -3,4 +3,4 @@ global:
 
 image:
   repository: rancher/system-upgrade-controller
-  tag: v0.3.1
+  tag: v0.4.0-rc1


### PR DESCRIPTION
- picks up rancher/system-upgrade-controller#48 to mitigate rancher/rancher#25882
- bumps backofflimit up to 99 (whole lotta retries)