### PR TITLE
set image pull policy for upgrade job containers to always

### DIFF
--- a/charts/rancher-k3s-upgrader/v0.0.1/templates/configmap.yaml
+++ b/charts/rancher-k3s-upgrader/v0.0.1/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
   SYSTEM_UPGRADE_CONTROLLER_THREADS: {{ .Values.systemUpgradeControllerThreads | default "2" | quote }}
   SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: {{ .Values.systemUpgradeJobActiveDeadlineSeconds | default "900" | quote }}
   SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: {{ .Values.systemUpgradeJobBackoffLimit | default "99" | quote }}
-  SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: {{ .Values.systemUpgradeJobImagePullPolicy | default "IfNotPresent" | quote }}
+  SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: {{ .Values.systemUpgradeJobImagePullPolicy | default "Always" | quote }}
   SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: {{ .Values.systemUpgradeJobKubectlImage | default "rancher/kubectl:v1.17.0" | quote }}
   SYSTEM_UPGRADE_JOB_PRIVILEGED: {{ .Values.systemUpgradeJobPrivileged | default "true" | quote }}
   SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: {{ .Values.systemUpgradeJobTTLSecondsAfterFinish | default "900" | quote }}


### PR DESCRIPTION
This mitigates a scenario such as rancher/rancher#25907 that may need to pull down a fixed upgrade/prepare image to be able to successfully apply the upgrade.