### PR TITLE
Adding a pre-delete hook - job to delete constrainttemplate crds

### DIFF
--- a/charts/rancher-gatekeeper-operator/v0.1.0/templates/job-constraints-crd.yaml
+++ b/charts/rancher-gatekeeper-operator/v0.1.0/templates/job-constraints-crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: gatekeeper-delete-constraints-crd-job
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-delete-policy": "hook-succeeded, before-hook-creation, hook-failed"
+spec:
+  template:
+    spec:
+      serviceAccountName: gatekeeper-admin
+      containers:
+      - name: gatekeeper-delete-constraints-crd
+        image: "{{ template "system_default_registry" . }}{{ .Values.global.kubectl.repository }}:{{ .Values.global.kubectl.tag }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        command: ["kubectl",  "delete", "constrainttemplates", "--all", "--wait=false"]
+      restartPolicy: Never
+  backoffLimit: 1

--- a/charts/rancher-gatekeeper-operator/v0.1.0/values.yaml
+++ b/charts/rancher-gatekeeper-operator/v0.1.0/values.yaml
@@ -17,3 +17,6 @@ resources:
     memory: 256Mi
 global:
   systemDefaultRegistry: ""
+  kubectl:
+    repository: rancher/istio-kubectl
+    tag: 1.4.6


### PR DESCRIPTION
https://github.com/rancher/rancher/pull/25575

Adding in a pre-delete hook to the helm chart to clean up OPA Gatekeeper constrainttemplates during removal of the helm release.
