### PR TITLE
Recording rule for apiserver metrics

### DIFF
--- a/charts/rancher-monitoring/v0.0.8/charts/exporter-kubernetes/templates/recording-rule.yaml
+++ b/charts/rancher-monitoring/v0.0.8/charts/exporter-kubernetes/templates/recording-rule.yaml
@@ -1,0 +1,19 @@
+{{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.version" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    source: rancher-monitoring
+  name: compatible-v117-deprecated-apiserver-metrics
+  namespace: {{ .Release.Namespace }}
+spec:
+  groups:
+  - name: apiserver_metrics.rules
+    rules:
+    - record: apiserver_request_count
+      expr: apiserver_request_total
+{{- end }}


### PR DESCRIPTION
The metric `apiserver_request_count` was renamed to `apiserver_request_total`, and the deprecated `apiserver_request_count` was removed from k8s 1.17
This PR adds recording rule to rename `apiserver_request_count` to `apiserver_request_total` for clusters with k8s version 1.17 and up

https://github.com/kubernetes/kubernetes/pull/72336
https://github.com/kubernetes/apiserver/blob/master/pkg/endpoints/metrics/metrics.go