### PR TITLE
Wait for all constraints to be deleted

### DIFF
--- a/charts/rancher-gatekeeper-operator/v0.1.0/templates/job-constraints-crd.yaml
+++ b/charts/rancher-gatekeeper-operator/v0.1.0/templates/job-constraints-crd.yaml
@@ -14,6 +14,6 @@ spec:
       - name: gatekeeper-delete-constraints-crd
         image: "{{ template "system_default_registry" . }}{{ .Values.global.kubectl.repository }}:{{ .Values.global.kubectl.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-        command: ["kubectl",  "delete", "constrainttemplates", "--all", "--wait=false"]
+        command: ["kubectl",  "delete", "constrainttemplates", "--all"]
       restartPolicy: Never
   backoffLimit: 1


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/25575

kubectl delete  command used the  "--wait=false" flag - this causes kubectl to not wait for the whole deletion process to complete.

When there is some constraint created for a constrainttemplate then on deleting that gatekeeper's controller is invoked that needs to clear the finalizer before the delete. If kubectl delete command returns without waiting for the gatekeeper to remove the finalizer, the constrainttemplate does not get deleted.

Removing the flag causes kubectl to wait for gatekeeper to remove finalizers and ensures clean delete.

