### PR TITLE
Increasing audit interval so that edit constraint usecase errors out less frequently

### DIFF
--- a/charts/rancher-gatekeeper-operator/v0.1.0/values.yaml
+++ b/charts/rancher-gatekeeper-operator/v0.1.0/values.yaml
@@ -1,5 +1,5 @@
 replicas: 1
-auditInterval: 60
+auditInterval: 300
 constraintViolationsLimit: 20
 auditFromCache: false
 image:


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/25816

This is to make gatekeeper's audit run on a 5 minute interval by default instead of every minute - This will lessen the occurance of hitting an error while editing a constraint.

The ticket is dependent on an upstream issue; but this can be done for our system chart for v2.4 to help.