### PR TITLE
Remove cluster-service annotation from access-thanos resource

### DIFF
--- a/charts/rancher-monitoring/v0.1.0/charts/prometheus/templates/service.yaml
+++ b/charts/rancher-monitoring/v0.1.0/charts/prometheus/templates/service.yaml
@@ -31,7 +31,6 @@ metadata:
     chart: {{ template "app.version" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    kubernetes.io/cluster-service: "true"
 spec:
   type: ClusterIP
   sessionAffinity: ClientIP


### PR DESCRIPTION
Currently the annotation:
```kubernetes.io/cluster-service: "true"```
Causes the rancher UI to render a link under the monitoring app's endpoints section for thanos.

- https://.../k8s/clusters/c-id/api/v1/namespaces/cattle-prometheus/services/access-thanos:10901/proxy/
- https://.../k8s/clusters/c-id/api/v1/namespaces/cattle-prometheus/services/access-thanos:10902/proxy/

Since these endpoints don't serve any purpose as links in Rancher, it seems best to remove the annotation to avoid confusion.

Similarly the node exporters also provide links that don't seem to serve a purpose, I'd be happy to PR a similar change for that chart