### PR TITLE
Change to use the rancher generated image instead of upstream

### DIFF
--- a/charts/rancher-gatekeeper-operator/0.1.1/values.yaml
+++ b/charts/rancher-gatekeeper-operator/0.1.1/values.yaml
@@ -3,7 +3,7 @@ auditInterval: 300
 constraintViolationsLimit: 20
 auditFromCache: false
 image:
-  repository: quay.io/open-policy-agent/gatekeeper
+  repository: rancher/opa-gatekeeper
   tag: v3.1.0-beta.8
   pullPolicy: IfNotPresent
 nodeSelector: {"beta.kubernetes.io/os": "linux"}


### PR DESCRIPTION
We need to use the rancher generated image instead of the upstream image directly. The corresponding rancher PR to generate the image is already merged to master: 
https://github.com/rancher/rancher/pull/26517