### PR TITLE
Update Rancher min version for monitoring v0.1.0

### DIFF
--- a/charts/rancher-monitoring/v0.1.0/questions.yml
+++ b/charts/rancher-monitoring/v0.1.0/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.4.0-rc1
+rancher_min_version: 2.3.7-rc1


### PR DESCRIPTION
Update Rancher min version for monitoring v0.1.0 to keep it the same with monitoring v0.1.0 in v2.3 branch