### PR TITLE
rancher-monitoring: support prometheus/alertmanager-instance-namespaces

### DIFF
--- a/charts/rancher-monitoring/v0.1.0/Chart.yaml
+++ b/charts/rancher-monitoring/v0.1.0/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: rancher-monitoring
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/charts/rancher-monitoring/v0.1.0/charts/operator/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.1.0/charts/operator/templates/deployment.yaml
@@ -51,6 +51,12 @@ spec:
             - --crd-apigroup={{ template "operator_api_group" . }}
             - --manage-crds={{ .Values.manageCRDs }}
             - --with-validation={{ .Values.withValidation }}
+            {{- if .Values.prometheusInstanceNamespaces }}
+            - --prometheus-instance-namespaces={{ .Values.prometheusInstanceNamespaces | join "," }}
+            {{- end }}
+            {{- if .Values.alertmanagerInstanceNamespaces }}
+            - --alertmanager-instance-namespaces={{ .Values.alertmanagerInstanceNamespaces | join "," }}
+            {{- end }}
           ports:
           - containerPort: 8080
             name: http

--- a/charts/rancher-monitoring/v0.1.0/values.yaml
+++ b/charts/rancher-monitoring/v0.1.0/values.yaml
@@ -27,6 +27,8 @@ operator:
   ## Already exist ServiceAccount
   ##
   serviceAccountName: ""
+  prometheusInstanceNamespaces: []
+  alertmanagerInstanceNamespaces: []
 
 exporter-coredns:
   enabled: false


### PR DESCRIPTION
## What?

This PR introduces a new value `denyNamespaces` for the operator.
If this is specified, it will add the `--deny-namespaces=<list>` arg on the prometheus-operator.

## Why?

This is especially useful if someone tries to use another prometheus-operator on the same cluster.
E.g. I deployed the prometheus-operator helm chart to the namespace `prometheus-operator` (operator v0.38.1 and v0.39.0 testes) and the alertmanager and prometheus server failed to start, because they were constantly being updated by the operator.
Interestingly, this stopped when I added the `--deny-namespaces=prometheus-operator` arg to the operator in `cattle-prometheus` or when I deleted the `cattle-prometheus` namespace (which will automatically be recreated).
So I guess that the Rancher prometheus-operator and the custom deployed operator are fighting to update the resources, which then results in an update/termination loop.