### PR TITLE
CIS benchmark: Updating chart to use new  security-scan image

### DIFF
--- a/charts/rancher-cis-benchmark/0.1.1/.helmignore
+++ b/charts/rancher-cis-benchmark/0.1.1/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/rancher-cis-benchmark/0.1.1/Chart.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+appVersion: "0.1.0"
+description: |
+  Run CIS benhmark tests
+name: rancher-cis-benchmark
+version: 0.1.0
+home: https://github.com/rancher/system-charts/charts/rancher-cis-benchmark
+sources:
+  - "https://github.com/rancher/system-charts/charts/rancher-cis-benchmark"
+maintainers:
+  - name: Murali Paluru
+    email: leodotcloud@gmail.com

--- a/charts/rancher-cis-benchmark/0.1.1/Chart.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 description: |
   Run CIS benhmark tests
 name: rancher-cis-benchmark
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/rancher/system-charts/charts/rancher-cis-benchmark
 sources:
   - "https://github.com/rancher/system-charts/charts/rancher-cis-benchmark"

--- a/charts/rancher-cis-benchmark/0.1.1/questions.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/questions.yaml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.4.0-rc1

--- a/charts/rancher-cis-benchmark/0.1.1/questions.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/questions.yaml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.4.0-rc1
+rancher_min_version: 2.4.4-rc1

--- a/charts/rancher-cis-benchmark/0.1.1/templates/NOTES.txt
+++ b/charts/rancher-cis-benchmark/0.1.1/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "rancher-cis-benchmark.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "rancher-cis-benchmark.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "rancher-cis-benchmark.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "rancher-cis-benchmark.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/rancher-cis-benchmark/0.1.1/templates/_helpers.tpl
+++ b/charts/rancher-cis-benchmark/0.1.1/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rancher-cis-benchmark.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rancher-cis-benchmark.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rancher-cis-benchmark.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-cis-benchmark/0.1.1/templates/configmap.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/templates/configmap.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    helm.sh/chart: {{ include "rancher-cis-benchmark.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: s-config-cm-{{ .Release.Name }}
+data:
+  config.json: |
+    {
+        "Description": "kube-bench plugin for CIS benchmarks",
+        "Filters": {
+            "LabelSelector": "",
+            "Namespaces": "[^\\w-.]+"
+        },
+        "PluginNamespace": "{{ .Release.Namespace }}",
+        "Plugins": [
+            {
+                "name": "rancher-kube-bench"
+            }
+        ],
+        "PluginSearchPath": [
+          "/plugins.d"
+        ],
+        "Resources": [],
+        "ResultsDir": "/tmp/sonobuoy",
+        "Server": {
+            "advertiseaddress": "{{ include "rancher-cis-benchmark.fullname" . }}",
+            "bindaddress": "0.0.0.0",
+            "bindport": 443,
+            "timeoutseconds": 5400
+        },
+        "Namespace": "{{ .Release.Namespace }}",
+        "WorkerImage": "{{ template "system_default_registry" . }}{{ .Values.image.sonobuoy.repository }}:{{ .Values.image.sonobuoy.tag }}",
+        "Version": "{{ .Values.image.sonobuoy.tag }}"
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    helm.sh/chart: {{ include "rancher-cis-benchmark.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: s-plugins-cm-{{ .Release.Name }}
+data:
+  rancher-kube-bench.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      serviceAccountName: s-sa-{{ .Release.Name }}
+      {{- if .Values.sonobuoy.tolerations }}
+      tolerations:
+{{ toYaml .Values.sonobuoy.tolerations | trim | indent 6 }}
+      {{- end }}
+      volumes:
+      - hostPath:
+          path: /
+        name: root
+      - hostPath:
+          path: /etc/passwd
+        name: etc-passwd
+      - hostPath:
+          path: /etc/group
+        name: etc-group
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: rancher-kube-bench
+      result-type: rancher-kube-bench
+      result-format: raw
+    spec:
+      name: rancher-kube-bench
+      image: '{{ template "system_default_registry" . }}{{ .Values.image.securityScan.repository }}:{{ .Values.image.securityScan.tag }}'
+      command: ["/bin/bash", "-c", "run_sonobuoy_plugin.sh && sleep 3600"]
+      env:
+      - name: SONOBUOY_NS
+        value: {{ .Release.Namespace }}
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: RESULTS_DIR
+        value: /tmp/results
+      - name: CHROOT_DIR
+        value: /node
+      {{- if .Values.overrideBenchmarkVersion }}
+      - name: OVERRIDE_BENCHMARK_VERSION
+        value: {{ .Values.overrideBenchmarkVersion }}
+      {{- end }}
+      {{- if .Values.debugWorker }}
+      - name: DEBUG
+        value: "true"
+      - name: DEBUG_TIME_IN_SEC
+        value: {{ .Values.debugTime }}
+      {{- end }}
+      imagePullPolicy: Always
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+        readOnly: false
+      - mountPath: /node
+        name: root
+        readOnly: true
+      - mountPath: /etc/passwd
+        name: etc-passwd
+        readOnly: true
+      - mountPath: /etc/group
+        name: etc-group
+        readOnly: true

--- a/charts/rancher-cis-benchmark/0.1.1/templates/ingress.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "rancher-cis-benchmark.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    helm.sh/chart: {{ include "rancher-cis-benchmark.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/rancher-cis-benchmark/0.1.1/templates/pod.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/templates/pod.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-scan-runner-{{ .Release.Name }}
+  {{- if ne .Values.owner "" }}
+  annotations:
+    field.cattle.io/clusterScanOwner: "{{ .Values.owner }}"
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    helm.sh/chart: {{ include "rancher-cis-benchmark.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    run: sonobuoy-master
+spec:
+  serviceAccountName: s-sa-{{ .Release.Name }}
+  terminationGracePeriodSeconds: 0
+  volumes:
+    - configMap:
+        name: s-config-cm-{{ .Release.Name }}
+      name: s-config-volume
+    - configMap:
+        name: s-plugins-cm-{{ .Release.Name }}
+      name: s-plugins-volume
+    - emptyDir: {}
+      name: output-volume
+    {{- if ne .Values.userSkipConfigMapName "" }}
+    - configMap:
+        name: {{ .Values.userSkipConfigMapName }}
+      name: user-skip-info-volume
+    {{- end }}
+    {{- if ne .Values.defaultSkipConfigMapName "" }}
+    - configMap:
+        name: {{ .Values.defaultSkipConfigMapName }}
+      name: default-skip-info-volume
+    {{- end }}
+    {{- if ne .Values.notApplicableConfigMapName "" }}
+    - configMap:
+        name: {{ .Values.notApplicableConfigMapName }}
+      name: not-applicable-info-volume
+    {{- end }}
+  containers:
+    - name: {{ .Chart.Name }}
+      restartPolicy: Never
+      env:
+        {{- if .Values.overrideBenchmarkVersion }}
+        - name: OVERRIDE_BENCHMARK_VERSION
+          value: {{ .Values.overrideBenchmarkVersion }}
+        {{- end }}
+        - name: SONOBUOY_NS
+          value: {{ .Release.Namespace }}
+        - name: SONOBUOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SONOBUOY_ADVERTISE_IP
+          value: {{ include "rancher-cis-benchmark.fullname" . }}
+        {{- if ne .Values.owner "" }}
+        - name: OUTPUT_CONFIGMAPNAME
+          value: {{ .Release.Name }}
+        {{- end }}
+        {{- if .Values.debugMaster }}
+        - name: DEBUG
+          value: "true"
+        - name: DEBUG_TIME_IN_SEC
+          value: {{ .Values.debugTime }}
+        {{- end }}
+      image: '{{ template "system_default_registry" . }}{{ .Values.image.securityScan.repository }}:{{ .Values.image.securityScan.tag }}'
+      imagePullPolicy: {{ .Values.image.securityScan.pullPolicy }}
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - mountPath: /etc/sonobuoy
+          name: s-config-volume
+        - mountPath: /plugins.d
+          name: s-plugins-volume
+        - mountPath: /tmp/sonobuoy
+          name: output-volume
+        {{- if ne .Values.userSkipConfigMapName "" }}
+        - mountPath: /etc/kbs/userskip
+          name: user-skip-info-volume
+        {{- end }}
+        {{- if ne .Values.defaultSkipConfigMapName "" }}
+        - mountPath: /etc/kbs/defaultskip
+          name: default-skip-info-volume
+        {{- end }}
+        {{- if ne .Values.notApplicableConfigMapName "" }}
+        - mountPath: /etc/kbs/notapplicable
+          name: not-applicable-info-volume
+        {{- end }}
+      resources:
+        {{- toYaml .Values.resources | nindent 12 }}
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+{{- with .Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 8 }}
+{{- end }}

--- a/charts/rancher-cis-benchmark/0.1.1/templates/rbac.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/templates/rbac.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    helm.sh/chart: {{ include "rancher-cis-benchmark.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: s-sa-{{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    helm.sh/chart: {{ include "rancher-cis-benchmark.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: s-sa-{{ .Release.Name }}
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    helm.sh/chart: {{ include "rancher-cis-benchmark.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: s-sa-{{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: s-sa-{{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: s-sa-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/rancher-cis-benchmark/0.1.1/templates/service.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rancher-cis-benchmark.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    helm.sh/chart: {{ include "rancher-cis-benchmark.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 443
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "rancher-cis-benchmark.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/rancher-cis-benchmark/0.1.1/values.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/values.yaml
@@ -1,0 +1,77 @@
+# Default values for rancher-cis-benchmark.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+# if owner is specified, it's used for the name of the configmap for results
+owner: ""
+# userSkipConfigMapName is used to specify the name of cm where user skip info is stored
+userSkipConfigMapName: ""
+# defaultSkipConfigMapName is used to specify the name of cm where default skip info is stored
+defaultSkipConfigMapName: ""
+# notApplicableConfigMapName
+notApplicableConfigMapName: ""
+# overrideBenchmarkVersion is used to override the default benchmark version used for
+# a particular k8s version
+overrideBenchmarkVersion: ""
+
+# when debug=true, the plugin pods sleep for the time specified
+debugMaster: false
+debugWorker: false
+debugTime: "infinity"
+
+sonobuoy:
+  tolerations: []
+
+image:
+  securityScan:
+    repository: rancher/security-scan
+    tag: v0.1.9
+    pullPolicy: Always
+  sonobuoy:
+    repository: rancher/sonobuoy-sonobuoy
+    tag: v0.16.3
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 443
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: 
+- operator: Exists
+
+affinity: {}
+
+global:
+  systemDefaultRegistry: ""

--- a/charts/rancher-cis-benchmark/0.1.1/values.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/values.yaml
@@ -27,7 +27,7 @@ sonobuoy:
 image:
   securityScan:
     repository: rancher/security-scan
-    tag: v0.1.9
+    tag: v0.1.10
     pullPolicy: Always
   sonobuoy:
     repository: rancher/sonobuoy-sonobuoy


### PR DESCRIPTION
There is a new image  rancher/security-scan:v0.1.10

This brings in the fixes necessary for CIS 1.5 tests.