### PR TITLE
Updating the new version to use the latest new rancher/security-scan tag

### DIFF
--- a/charts/rancher-cis-benchmark/0.1.1/values.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/values.yaml
@@ -27,7 +27,7 @@ sonobuoy:
 image:
   securityScan:
     repository: rancher/security-scan
-    tag: v0.1.10
+    tag: v0.1.11
     pullPolicy: Always
   sonobuoy:
     repository: rancher/sonobuoy-sonobuoy


### PR DESCRIPTION
New tag is released for rancher/security-scan image; updating to use this tag.