### PR TITLE
[2.5]Set max version 2.4.4 for monitoring v0.1.0

### DIFF
--- a/charts/rancher-monitoring/v0.1.0/questions.yml
+++ b/charts/rancher-monitoring/v0.1.0/questions.yml
@@ -1,2 +1,2 @@
 rancher_min_version: 2.4.0-rc1
-rancher_max_version: 2.4.0-rc1
+rancher_max_version: 2.4.4


### PR DESCRIPTION
@deniseschannon I changed this to allow v0.1.0 to be used between 2.4.0 and 2.4.4. Let me know if this is what you want.