### PR TITLE
Updating CIS charts mix-max versions for 2.4.5 release

### DIFF
--- a/charts/rancher-cis-benchmark/0.1.0/questions.yaml
+++ b/charts/rancher-cis-benchmark/0.1.0/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.4.0-rc1
+rancher_max_version: 2.4.4

--- a/charts/rancher-cis-benchmark/0.1.1/questions.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/questions.yaml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.4.4-rc1
+rancher_min_version: 2.4.5-rc1


### PR DESCRIPTION
ForwardPort PR for 2.5 branch: https://github.com/rancher/system-charts/pull/255

For CIS chart 0.1.1: Update rancher_min_version: 2.4.5-rc1

For CIS chart 0.1.0: Update rancher_max_version: 2.4.4

