### PR TITLE
remove grafana from istio chart to fix images.txt script

### DIFF
--- a/charts/rancher-istio/1.5.700/charts/grafana/values.yaml
+++ b/charts/rancher-istio/1.5.700/charts/grafana/values.yaml
@@ -3,9 +3,6 @@
 #
 enabled: false
 replicaCount: 1
-image:
-  repository: grafana/grafana
-  tag: 6.4.3
 ingress:
   enabled: false
   ## Used to create an Ingress record.

--- a/scripts/istio/patch-istio-images.patch
+++ b/scripts/istio/patch-istio-images.patch
@@ -434,6 +434,20 @@ index 5e50f52..9682361 100755
  
  #
  # sidecar-injector webhook configuration, refer to the
+diff --git a/charts/rancher-istio/tagreplace/charts/grafana/values.yaml b/charts/rancher-istio/tagreplace/charts/grafana/values.yaml
+index 2c272bf..7b977c1 100755
+--- a/charts/rancher-istio/tagreplace/charts/grafana/values.yaml
++++ b/charts/rancher-istio/tagreplace/charts/grafana/values.yaml
+@@ -3,9 +3,6 @@
+ #
+ enabled: false
+ replicaCount: 1
+-image:
+-  repository: grafana/grafana
+-  tag: 6.4.3
+ ingress:
+   enabled: false
+   ## Used to create an Ingress record.
 diff --git a/charts/rancher-istio/tagreplace/charts/certmanager/values.yaml b/charts/rancher-istio/tagreplace/charts/certmanager/values.yaml
 index 01e565c..2dbff4b 100755
 --- a/charts/rancher-istio/tagreplace/charts/certmanager/values.yaml

--- a/scripts/update-istio-release
+++ b/scripts/update-istio-release
@@ -83,7 +83,7 @@ done
 rm -r charts/rancher-istio/$R_VERSION/charts/istio-init
 
 # Add question.yaml, make need to update minimum rancher version
-RANCHER_MIN_VERSION="2.3.4-rc1"
+RANCHER_MIN_VERSION="2.4.5-rc1"
 echo "Current rancher min version is set to $RANCHER_MIN_VERSION"
 
 cat > charts/rancher-istio/$R_VERSION/questions.yaml << EOF


### PR DESCRIPTION
When trying to generate rancher-images.txt I realized that we need to remove grafana image definition from sub-chart. Grafana defines their image the same way the script is looking for, and the script fails anything that matches that and isn't from rancher dockerhub. 