### PR TITLE
bump SUC version, rancher-k3s-upgrader chart version

### DIFF
--- a/charts/rancher-k3s-upgrader/0.2.0/Chart.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+name: rancher-k3s-upgrader
+description: Enables a k3s cluster to update itself by reacting to Plan CRs.
+home: https://github.com/rancher/system-charts/charts/system-upgrade-controller
+sources:
+  - "https://github.com/rancher/system-charts/charts/system-upgrade-controller"
+version: 0.1.0
+appVersion: v0.4.0

--- a/charts/rancher-k3s-upgrader/0.2.0/Chart.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/Chart.yaml
@@ -4,5 +4,5 @@ description: Enables a k3s cluster to update itself by reacting to Plan CRs.
 home: https://github.com/rancher/system-charts/charts/system-upgrade-controller
 sources:
   - "https://github.com/rancher/system-charts/charts/system-upgrade-controller"
-version: 0.1.0
-appVersion: v0.4.0
+version: 0.2.0
+appVersion: v0.6.2

--- a/charts/rancher-k3s-upgrader/0.2.0/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.2.0/questions.yml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.4.0-rc1

--- a/charts/rancher-k3s-upgrader/0.2.0/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.2.0/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.4.0-rc1
+rancher_min_version: 2.5.0-rc1

--- a/charts/rancher-k3s-upgrader/0.2.0/templates/NOTES.txt
+++ b/charts/rancher-k3s-upgrader/0.2.0/templates/NOTES.txt
@@ -1,0 +1,4 @@
+You have deployed the Rancher K3s Upgrader
+Version: {{ .Chart.AppVersion }}
+Description: This controller enables a k3s cluster to update itself by
+reacting to Plan CRs.

--- a/charts/rancher-k3s-upgrader/0.2.0/templates/_helpers.tpl
+++ b/charts/rancher-k3s-upgrader/0.2.0/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-k3s-upgrader/0.2.0/templates/clusterrolebinding.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  system-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+  namespace: cattle-system

--- a/charts/rancher-k3s-upgrader/0.2.0/templates/configmap.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-controller-env
+  namespace: cattle-system
+data:
+  SYSTEM_UPGRADE_CONTROLLER_DEBUG: {{ .Values.systemUpgradeControllerDebug | default "false" | quote }}
+  SYSTEM_UPGRADE_CONTROLLER_THREADS: {{ .Values.systemUpgradeControllerThreads | default "2" | quote }}
+  SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: {{ .Values.systemUpgradeJobActiveDeadlineSeconds | default "900" | quote }}
+  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: {{ .Values.systemUpgradeJobBackoffLimit | default "99" | quote }}
+  SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: {{ .Values.systemUpgradeJobImagePullPolicy | default "Always" | quote }}
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: {{ template "system_default_registry" . }}{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+  SYSTEM_UPGRADE_JOB_PRIVILEGED: {{ .Values.systemUpgradeJobPrivileged | default "true" | quote }}
+  SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: {{ .Values.systemUpgradeJobTTLSecondsAfterFinish | default "900" | quote }}
+  SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL: {{ .Values.systemUpgradePlanRollingInterval | default "15m" | quote }}
+

--- a/charts/rancher-k3s-upgrader/0.2.0/templates/deployment.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-upgrade-controller
+  namespace: cattle-system
+spec:
+  selector:
+    matchLabels:
+      upgrade.cattle.io/controller: system-upgrade-controller
+  template:
+    metadata:
+      labels:
+        upgrade.cattle.io/controller: system-upgrade-controller # necessary to avoid drain
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: "node-role.kubernetes.io/master", operator: In, values: ["true"]}
+      serviceAccountName: system-upgrade
+      containers:
+        - name: system-upgrade-controller
+          image: {{ template "system_default_registry" . }}{{ .Values.systemUpgradeController.image.repository }}:{{ .Values.systemUpgradeController.image.tag }}
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: default-controller-env
+          env:
+            - name: SYSTEM_UPGRADE_CONTROLLER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['upgrade.cattle.io/controller']
+            - name: SYSTEM_UPGRADE_CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: etc-ssl
+              mountPath: /etc/ssl
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: etc-ssl
+          hostPath:
+            path: /etc/ssl
+            type: Directory
+        - name: tmp
+          emptyDir: {}

--- a/charts/rancher-k3s-upgrader/0.2.0/templates/namespace.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cattle-system

--- a/charts/rancher-k3s-upgrader/0.2.0/templates/serviceaccount.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: system-upgrade
+  namespace: cattle-system

--- a/charts/rancher-k3s-upgrader/0.2.0/values.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/values.yaml
@@ -1,0 +1,12 @@
+global:
+  systemDefaultRegistry: ""
+
+systemUpgradeController:
+  image:
+    repository: rancher/system-upgrade-controller
+    tag: v0.4.0
+
+kubectl:
+  image:
+    repository: rancher/kubectl
+    tag: v1.17.0

--- a/charts/rancher-k3s-upgrader/0.2.0/values.yaml
+++ b/charts/rancher-k3s-upgrader/0.2.0/values.yaml
@@ -4,9 +4,9 @@ global:
 systemUpgradeController:
   image:
     repository: rancher/system-upgrade-controller
-    tag: v0.4.0
+    tag: v0.6.2
 
 kubectl:
   image:
     repository: rancher/kubectl
-    tag: v1.17.0
+    tag: v1.18.0


### PR DESCRIPTION
changes : 
- create rancher-k3s-upgrader 0.2.0 dir
- SUC version bump to v0.6.2
- kubectl version bump to v1.18.0


in reference to https://github.com/rancher/rancher/pull/27702