### PR TITLE
Make enabling/disabling Grafana reporting simpler

### DIFF
--- a/charts/rancher-monitoring/v0.1.2/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.1.2/charts/grafana/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
         - name: GF_ANALYTICS_REPORTING_ENABLED
-          value: {{ .Values.reportingEnabled }}
+          value: "{{ .Values.reportingEnabled }}"
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 8 }}
 {{- end }}

--- a/charts/rancher-monitoring/v0.1.2/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.1.2/charts/grafana/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
           value: "true"
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
+        - name: GF_ANALYTICS_REPORTING_ENABLED
+          value: {{ .Values.reportingEnabled }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 8 }}
 {{- end }}

--- a/charts/rancher-monitoring/v0.1.2/charts/grafana/values.yaml
+++ b/charts/rancher-monitoring/v0.1.2/charts/grafana/values.yaml
@@ -1,4 +1,5 @@
 enabledRBAC: true
+reportingEnabled: true
 
 ## Tolerations for use with node taints
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
Will at least make this a little more user friendly:

https://github.com/rancher/rancher/issues/28064

Didn't change the default as reporting_enabled still defaults to true.