### PR TITLE
bump up rancher/fluentd version to v0.1.21

### DIFF
--- a/charts/rancher-logging/0.2.2/charts/fluentd-tester/values.yaml
+++ b/charts/rancher-logging/0.2.2/charts/fluentd-tester/values.yaml
@@ -2,7 +2,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.20
+  tag: v0.1.21
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/rancher-logging/0.2.2/charts/fluentd/charts/fluentd-linux/values.yaml
+++ b/charts/rancher-logging/0.2.2/charts/fluentd/charts/fluentd-linux/values.yaml
@@ -3,7 +3,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.20
+  tag: v0.1.21
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/rancher-logging/0.2.2/charts/fluentd/charts/fluentd-windows/values.yaml
+++ b/charts/rancher-logging/0.2.2/charts/fluentd/charts/fluentd-windows/values.yaml
@@ -4,7 +4,7 @@ labels: {}
 image:
   os: windows
   repository: rancher/fluentd
-  tag: v0.1.20
+  tag: v0.1.21
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
Problem:
We already add label in rancher FLUENT_LOG, if we also add FLUENT_LOG here will get duplicated configuration error.

Solution:
Remove FLUENT_LOG label.

Issue:
https://github.com/rancher/rancher/issues/26543