### PR TITLE
bump eks-operator to v0.1.0-rc23

### DIFF
--- a/charts/rancher-eks-operator/0.1.0/Chart.yaml
+++ b/charts/rancher-eks-operator/0.1.0/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/rancher/eks-operator
 sources:
   - "https://github.com/rancher/eks-operator"
 version: 0.1.0
-appVersion: v0.1.0-rc22
+appVersion: v0.1.0-rc23

--- a/charts/rancher-eks-operator/0.1.0/values.yaml
+++ b/charts/rancher-eks-operator/0.1.0/values.yaml
@@ -4,4 +4,4 @@ global:
 eksOperator:
   image:
     repository: rancher/eks-operator
-    tag: v0.1.0-rc22
+    tag: v0.1.0-rc23


### PR DESCRIPTION
**Problem:**
Provided networking field aren't working

If the VirtualNetwork field on status is empty, it is assumed that network fields were not provided. The controller then generates them. The VirtualNetwork field is always empty at the beginning of an EKS cluster being created regardless of if the network fields are provided or not. This causes the controlplane and nodegroups to use subnets belonging to different VPC's and for the controlplane to use the provided fields. This is invalid and causes an error.

**Solution:**
Now, the provider is determined by evaluating whether subnets have been provided or not. Also, nodegroups will now use the networking fields on status which should match what the cluster is using.

**Issues:**
https://github.com/rancher/rancher/issues/28144
https://github.com/rancher/rancher/issues/27709