### PR TITLE
Updating the security-scan image tag, adding min/max versions

### DIFF
--- a/charts/rancher-cis-benchmark/0.1.1/questions.yaml
+++ b/charts/rancher-cis-benchmark/0.1.1/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.4.5-rc1
+rancher_max_version: 2.4.5

--- a/charts/rancher-cis-benchmark/0.1.2/questions.yaml
+++ b/charts/rancher-cis-benchmark/0.1.2/questions.yaml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.4.5-rc1
+rancher_min_version: 2.4.6-rc1

--- a/charts/rancher-cis-benchmark/0.1.2/values.yaml
+++ b/charts/rancher-cis-benchmark/0.1.2/values.yaml
@@ -27,7 +27,7 @@ sonobuoy:
 image:
   securityScan:
     repository: rancher/security-scan
-    tag: v0.1.12
+    tag: v0.1.13
     pullPolicy: Always
   sonobuoy:
     repository: rancher/sonobuoy-sonobuoy


### PR DESCRIPTION
This is forwardport PR of https://github.com/rancher/system-charts/pull/301

For the fixes for rancher/rancher#26598 and rancher/rancher#28024