### PR TITLE
Added functionality to automatically load custom grafana dashboards from correctly labeled configmaps

### DIFF
--- a/charts/rancher-monitoring/v0.1.3/README.md
+++ b/charts/rancher-monitoring/v0.1.3/README.md
@@ -8,6 +8,7 @@ Installs [prometheus-operator](https://github.com/coreos/prometheus-operator) to
 
 * 0.1.3
     * Added chart webhook-receiver to support recipients that are not directly supported by Prometheus
+    * Added functionality to automatically load custom grafana dashboards from correclty labeled configmaps
 
 ## Prerequisites
   - >= Rancher 2.3.3

--- a/charts/rancher-monitoring/v0.1.3/charts/grafana/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.1.3/charts/grafana/templates/deployment.yaml
@@ -49,6 +49,25 @@ spec:
         - name: grafana-static-contents
           mountPath: /host
       containers:
+      {{- if .Values.customDashboards.enabled }}
+      - name: grafana-sc-dashboard
+        image: "kiwigrid/k8s-sidecar:0.1.151"
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: METHOD
+            value:
+          - name: LABEL
+            value: "{{ .Values.customDashboards.label }}"
+          - name: FOLDER
+            value: "/var/lib/grafana/custom-dashboards"
+          - name: RESOURCE
+            value: "both"
+        resources:
+          {}
+        volumeMounts:
+          - name: sc-custom-dashboards
+            mountPath: "/var/lib/grafana/custom-dashboards"
+      {{- end }}
       - name: grafana
         image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
         env:
@@ -69,6 +88,10 @@ spec:
           mountPath: /var/lib/grafana/rancher-dashboards
         - name: grafana-istio-dashboards
           mountPath: /var/lib/grafana/rancher-istio-dashboards
+        {{- if .Values.customDashboards.enabled }}
+        - name: sc-custom-dashboards
+          mountPath: /var/lib/grafana/custom-dashboards
+        {{- end }}
         - name: grafana-provisionings
           mountPath: /etc/grafana/provisioning/dashboards/all.yaml
           subPath: dashboards.yaml
@@ -169,3 +192,7 @@ spec:
           name: {{ template "app.provisionings.fullname" . }}
       - name: nginx-home
         emptyDir: {}
+      {{- if .Values.customDashboards.enabled }}
+      - name: sc-custom-dashboards
+        emptyDir: {}
+      {{- end }}

--- a/charts/rancher-monitoring/v0.1.3/charts/grafana/templates/provisionings-configmap.yaml
+++ b/charts/rancher-monitoring/v0.1.3/charts/grafana/templates/provisionings-configmap.yaml
@@ -25,6 +25,15 @@ data:
       updateIntervalSeconds: 0 #never
       options:
         path: /var/lib/grafana/rancher-istio-dashboards
+    - name: CUSTOM_MONITORING
+      orgId: 3
+      folder: 'custom'
+      type: file
+      disableDeletion: false
+      updateIntervalSeconds: 10
+      allowUiUpdates: false
+      options:
+        path: /var/lib/grafana/custom-dashboards
 
 
   datasources.yaml: |+

--- a/charts/rancher-monitoring/v0.1.3/charts/prometheus/templates/rbac.yaml
+++ b/charts/rancher-monitoring/v0.1.3/charts/prometheus/templates/rbac.yaml
@@ -56,6 +56,7 @@ rules:
   resources:
   - namespaces
   - secrets
+  - configmaps
   verbs:
   - "list"
   - "watch"


### PR DESCRIPTION
This PR contains grafana helmchart enhancement with new feature for grafana dashboards loading.

In values.yaml of rancher-monitoring helmchart one can enable customDashboards feature in grafana section and set its own label for dashboards configmaps.

```
customDashboards:
    enabled: true
    label: grafana_dashboard
```
This setting will deploy additional side-car container into grafana pod, which is instantly checking configmaps in namespace where grafana is deployed (by default cattle-prometheus).
Each configmap which contains grafana dashboard json definition should be correctly labeled.

For instance label is set by default to: grafana_dashboard

in metadata section of configmap have to be placed label as below:
```
labels:
    grafana_dashboard: "1"
```
once configmap with grafana dashboard json definition is correctly labeled, is then automatically loaded in grafana UI under custom folder

Signed-off-by: Jaroslav Vojtek jarusvojtek@gmail.com