### PR TITLE
Restore namespace of metrics when available

### DIFF
--- a/charts/rancher-monitoring/v0.1.3/charts/exporter-kubelets/templates/servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.3/charts/exporter-kubelets/templates/servicemonitor.yaml
@@ -45,6 +45,12 @@ spec:
       action: replace
       regex: (.+)
       replacement: $1
+    metricRelabelings:
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+      - exported_namespace
+      targetLabel: namespace
   - port: https-metrics
     scheme: https
     path: /metrics/cadvisor
@@ -71,6 +77,11 @@ spec:
     metricRelabelings:
     - action: labeldrop
       regex: (^id$|^image$|^name$|^cpu$)
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+      - exported_namespace
+      targetLabel: namespace
     {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
     - action: replace
       regex: (.+)
@@ -108,6 +119,11 @@ spec:
       sourceLabels:
       - pod
       targetLabel: pod_name
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+      - exported_namespace
+      targetLabel: namespace
   {{- else }}
   - port: http-metrics
     relabelings:
@@ -123,6 +139,12 @@ spec:
       action: replace
       regex: (.+)
       replacement: $1
+    metricRelabelings:
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+      - exported_namespace
+      targetLabel: namespace
   - port: http-metrics
     path: /metrics/cadvisor
     honorLabels: true
@@ -142,6 +164,11 @@ spec:
     metricRelabelings:
     - action: labeldrop
       regex: (^id$|^image$|^name$|^cpu$)
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+      - exported_namespace
+      targetLabel: namespace
     {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
     - action: replace
       regex: (.+)
@@ -172,4 +199,9 @@ spec:
       sourceLabels:
       - pod
       targetLabel: pod_name
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+      - exported_namespace
+      targetLabel: namespace
   {{- end }}

--- a/charts/rancher-monitoring/v0.1.3/charts/exporter-kubelets/templates/servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.3/charts/exporter-kubelets/templates/servicemonitor.yaml
@@ -77,11 +77,6 @@ spec:
     metricRelabelings:
     - action: labeldrop
       regex: (^id$|^image$|^name$|^cpu$)
-    - action: replace
-      regex: (.+)
-      sourceLabels:
-      - exported_namespace
-      targetLabel: namespace
     {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
     - action: replace
       regex: (.+)
@@ -119,11 +114,6 @@ spec:
       sourceLabels:
       - pod
       targetLabel: pod_name
-    - action: replace
-      regex: (.+)
-      sourceLabels:
-      - exported_namespace
-      targetLabel: namespace
   {{- else }}
   - port: http-metrics
     relabelings:
@@ -164,11 +154,6 @@ spec:
     metricRelabelings:
     - action: labeldrop
       regex: (^id$|^image$|^name$|^cpu$)
-    - action: replace
-      regex: (.+)
-      sourceLabels:
-      - exported_namespace
-      targetLabel: namespace
     {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
     - action: replace
       regex: (.+)
@@ -199,9 +184,4 @@ spec:
       sourceLabels:
       - pod
       targetLabel: pod_name
-    - action: replace
-      regex: (.+)
-      sourceLabels:
-      - exported_namespace
-      targetLabel: namespace
   {{- end }}


### PR DESCRIPTION
This will enable federation of these statistics to the project monitoring Prometheus.

See https://github.com/rancher/rancher/issues/28394