### PR TITLE
Remove namespace template

### DIFF
--- a/charts/rancher-eks-operator/0.1.0/templates/deployment.yaml
+++ b/charts/rancher-eks-operator/0.1.0/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: eks-config-operator
   namespace: cattle-system
 spec:
+  replicas: 1
   selector:
     matchLabels:
       ke.cattle.io/operator: eks

--- a/charts/rancher-eks-operator/0.1.0/templates/namespace.yaml
+++ b/charts/rancher-eks-operator/0.1.0/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cattle-system


### PR DESCRIPTION
**Problem:**
Prior, the cattle-system namespace would be uninstalled on app uninstall causing all resources contained in the cattle-system namespace to be uninstalled.

**Solution:**
It is not necessary for the namespace to be a part of the chart. The cattle-system namespace will likely exist prior to an attempt to deploy the app. If not, an error will be returned in rancher and the app will be deployed once the namespace is available.

**Issue:**
https://github.com/rancher/rancher/issues/28535