### PR TITLE
Update istio tracing chart to use a serviceaccount as other istio components

### DIFF
--- a/charts/rancher-istio/1.5.900/charts/tracing/templates/deployment-jaeger.yaml
+++ b/charts/rancher-istio/1.5.900/charts/tracing/templates/deployment-jaeger.yaml
@@ -29,6 +29,7 @@ spec:
 {{ toYaml .Values.jaeger.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      serviceAccountName: istio-tracing-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}

--- a/charts/rancher-istio/1.5.900/charts/tracing/templates/deployment-zipkin.yaml
+++ b/charts/rancher-istio/1.5.900/charts/tracing/templates/deployment-zipkin.yaml
@@ -28,6 +28,7 @@ spec:
 {{ toYaml .Values.zipkin.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      serviceAccountName: istio-tracing-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}

--- a/charts/rancher-istio/1.5.900/charts/tracing/templates/serviceaccount.yaml
+++ b/charts/rancher-istio/1.5.900/charts/tracing/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+metadata:
+  name: istio-tracing-service-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.provider }}
+    chart: {{ template "tracing.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}


### PR DESCRIPTION
As we use pod security policies and we don't want to use default serviceaccount of namespace istio-system for security reasons, please use serviceaccount for istio tracing  as other istio components

Thank you,

Regards,

David