### PR TITLE
Do not uninstall CRD

### DIFF
--- a/charts/rancher-eks-operator/0.1.0/templates/eksclusterconfig.yaml
+++ b/charts/rancher-eks-operator/0.1.0/templates/eksclusterconfig.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eksclusterconfigs.eks.cattle.io
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: eks.cattle.io
   names:


### PR DESCRIPTION
**Problem:**
Deleting the eks-operator app deletes the eksclusterconfig crd which causes eks cluster that are up at deletion to start deleting and prevents new eks clusters from being created.

**Solution:**
Do not delete crd on app deletion. Crd will still be updated on upgrade.

**Issue:**
https://github.com/rancher/rancher/issues/28535
