### PR TITLE
add max version to monitoring 0.1.2

### DIFF
--- a/charts/rancher-monitoring/v0.1.2/questions.yml
+++ b/charts/rancher-monitoring/v0.1.2/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.4.6-rc1
+rancher_max_version: 2.4.99


### PR DESCRIPTION
We are adding 0.1.3 into 2.5 with min of 2.5, so 0.1.2 should max in 2.4. 

issue: https://github.com/rancher/rancher/issues/29049