### PR TITLE
[2.4] Remove prereqs section from README

### DIFF
--- a/charts/rancher-monitoring/v0.1.4/README.md
+++ b/charts/rancher-monitoring/v0.1.4/README.md
@@ -9,5 +9,3 @@ Installs [prometheus-operator](https://github.com/coreos/prometheus-operator) to
 * 0.1.2
     * Added chart webhook-receiver to support recipients that are not directly supported by Prometheus
 
-## Prerequisites
-  - >= Rancher 2.3.3


### PR DESCRIPTION
Getting rid of the prerequisite section because it's already documented in the `questions.yml`.