### PR TITLE
Add batch size to avoid rate limits

### DIFF
--- a/charts/rancher-external-dns/v0.1.1/templates/deployment.yaml
+++ b/charts/rancher-external-dns/v0.1.1/templates/deployment.yaml
@@ -80,6 +80,9 @@ spec:
           {{- if .Values.google.project }}
             - --google-project={{ .Values.google.project }}
           {{- end }}
+          {{- if eq .Values.provider "aws" }}
+            - --aws-batch-change-size=100
+          {{- end }}
           {{- if eq .Values.provider "infoblox" }}
             - --infoblox-grid-host={{ .Values.infoblox.gridHost }}
             {{- if .Values.infoblox.domainFilter }}

--- a/charts/rancher-external-dns/v0.1.1/templates/deployment.yaml
+++ b/charts/rancher-external-dns/v0.1.1/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             - --google-project={{ .Values.google.project }}
           {{- end }}
           {{- if eq .Values.provider "aws" }}
-            - --aws-batch-change-size=100
+            - --aws-batch-change-size={{ .Values.aws.batchChangeSize }}
           {{- end }}
           {{- if eq .Values.provider "infoblox" }}
             - --infoblox-grid-host={{ .Values.infoblox.gridHost }}

--- a/charts/rancher-external-dns/v0.1.1/values.yaml
+++ b/charts/rancher-external-dns/v0.1.1/values.yaml
@@ -34,6 +34,8 @@ aws:
   region: "us-east-1"
   # Filter for zones of this type (optional, options: public, private)
   zoneType: ""
+  # Batch size for Route53 changes
+  batchChangeSize: 100
 
 azure:
 # If you don't specify a secret to load azure.json from, you will get the host's /etc/kubernetes/azure.json


### PR DESCRIPTION
Avoid [Route53 API rate limits](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests) when large changes occur in a cluster, using a batch size of `100` as per https://github.com/zalando-incubator/kubernetes-on-aws/pull/2266/files

Related: https://github.com/rancher/rancher/issues/28391