### PR TITLE
Increasing replicas to allow nodes to drain with istio enabled

### DIFF
--- a/charts/rancher-istio/1.5.900/charts/galley/values.yaml
+++ b/charts/rancher-istio/1.5.900/charts/galley/values.yaml
@@ -2,7 +2,7 @@
 # galley configuration
 #
 enabled: true
-replicaCount: 1
+replicaCount: 2
 rollingMaxSurge: 100%
 rollingMaxUnavailable: 25%
 image: galley

--- a/charts/rancher-istio/1.5.900/charts/mixer/values.yaml
+++ b/charts/rancher-istio/1.5.900/charts/mixer/values.yaml
@@ -10,9 +10,9 @@ env:
 policy:
   # if policy is enabled, global.disablePolicyChecks has affect.
   enabled: false
-  replicaCount: 1
+  replicaCount: 2
   autoscaleEnabled: true
-  autoscaleMin: 1
+  autoscaleMin: 2
   autoscaleMax: 5
   cpu:
     targetAverageUtilization: 80
@@ -21,9 +21,9 @@ policy:
 
 telemetry:
   enabled: true
-  replicaCount: 1
+  replicaCount: 2
   autoscaleEnabled: true
-  autoscaleMin: 1
+  autoscaleMin: 2
   autoscaleMax: 5
   cpu:
     targetAverageUtilization: 80

--- a/charts/rancher-istio/1.5.900/charts/pilot/values.yaml
+++ b/charts/rancher-istio/1.5.900/charts/pilot/values.yaml
@@ -3,7 +3,7 @@
 #
 enabled: true
 autoscaleEnabled: true
-autoscaleMin: 1
+autoscaleMin: 2
 autoscaleMax: 5
 # specify replicaCount when autoscaleEnabled: false
 # replicaCount: 1

--- a/charts/rancher-istio/1.5.900/charts/security/values.yaml
+++ b/charts/rancher-istio/1.5.900/charts/security/values.yaml
@@ -2,7 +2,7 @@
 # security configuration
 #
 enabled: true
-replicaCount: 1
+replicaCount: 2
 rollingMaxSurge: 100%
 rollingMaxUnavailable: 25%
 image: citadel

--- a/charts/rancher-istio/1.5.900/charts/sidecarInjectorWebhook/values.yaml
+++ b/charts/rancher-istio/1.5.900/charts/sidecarInjectorWebhook/values.yaml
@@ -2,7 +2,7 @@
 # sidecar-injector webhook configuration
 #
 enabled: true
-replicaCount: 1
+replicaCount: 2
 rollingMaxSurge: 100%
 rollingMaxUnavailable: 25%
 image: sidecar_injector


### PR DESCRIPTION
mixer.telemetry.autoscaleMin=2
mixer.telemetry.replicaCount=2
mixer.policy.autoscaleMin=2
mixer.policy.replicaCount=2
pilot.autoscaleMin=2
galley.replicaCount=2
security.replicaCount=2
sidecarInjectorWebhook.replicaCount=2

fixes  rancher/rancher#30082