### PR TITLE
Bump eks-operator version

### DIFF
--- a/charts/rancher-eks-operator/1.0.500/Chart.yaml
+++ b/charts/rancher-eks-operator/1.0.500/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/rancher/eks-operator
 sources:
   - "https://github.com/rancher/eks-operator"
 version: 1.0.500
-appVersion: v1.0.5-rc1
+appVersion: v1.0.5-rc2

--- a/charts/rancher-eks-operator/1.0.500/values.yaml
+++ b/charts/rancher-eks-operator/1.0.500/values.yaml
@@ -4,7 +4,7 @@ global:
 eksOperator:
   image:
     repository: rancher/eks-operator
-    tag: v1.0.5-rc1
+    tag: v1.0.5-rc2
 
 httpProxy: ""
 httpsProxy: ""


### PR DESCRIPTION
This bump includes a fix for cluster name collision checking on imported/registered clusters.

Issue:
https://github.com/rancher/rancher/issues/29103

eks-operator PR:
https://github.com/rancher/eks-operator/pull/26