### PR TITLE
[2.5] Add crd-install hooks back into CRDs

### DIFF
--- a/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-alertmanager.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/hook: crd-install
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com

--- a/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-podmonitor.yaml
+++ b/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-podmonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/hook: crd-install
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com

--- a/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-prometheus.yaml
+++ b/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-prometheus.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/hook: crd-install
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com

--- a/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-prometheusrules.yaml
+++ b/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-prometheusrules.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/hook: crd-install
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com

--- a/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/hook: crd-install
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com

--- a/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-thanosrulers.yaml
+++ b/charts/rancher-monitoring/v0.2.0/charts/operator-init/files/crd-thanosrulers.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/hook: crd-install
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com


### PR DESCRIPTION
Context is in https://github.com/rancher/rancher/issues/29149#issuecomment-738992323.

Since Monitoring V1 is deployed via Helm 2 / Tiller, the crd-install fields seem to still be necessary. Otherwise, Tiller doesn't seem to realize that it needs to update the new field added to the CRD.

Related Issue: https://github.com/rancher/rancher/issues/29149