### PR TITLE
Update rancher_min_version to 2.5.4

### DIFF
--- a/charts/rancher-monitoring/v0.2.0/questions.yml
+++ b/charts/rancher-monitoring/v0.2.0/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.4.9-rc1
+rancher_min_version: 2.5.4-rc1


### PR DESCRIPTION
Chart has not been released into https://github.com/rancher/system-charts/tree/release-v2.5/charts/rancher-monitoring yet.

Required due to https://github.com/rancher/rancher/issues/29149#issuecomment-744724803.

Also required due to a Rancher update necessary, tracked here: https://github.com/rancher/rancher/pull/30486

Related Issue: https://github.com/rancher/rancher/issues/30453