### PR TITLE
Add rancher max version 2.5.3 to istio 1.4.1000

### DIFF
--- a/charts/rancher-istio/1.4.1000/questions.yaml
+++ b/charts/rancher-istio/1.4.1000/questions.yaml
@@ -1,3 +1,4 @@
 labels:
   rancher.istio.v1.4.1000: 1.4.10
 rancher_min_version: 2.3.8-rc1
+rancher_max_verson: 2.5.3


### PR DESCRIPTION
**Problem**
We only want to show 1 option for Istio v1 installation starting in 2.5.4

**Solution**
Add rancher max version 2.5.3 to istio 1.4.1000

**Issue**
https://github.com/rancher/rancher/issues/30507