### PR TITLE
Add logging 0.2.3 for temporary Windows Server 2019 LTSC / 1909 SAC branch

### DIFF
--- a/charts/rancher-logging/0.2.3/.helmignore
+++ b/charts/rancher-logging/0.2.3/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/rancher-logging/0.2.3/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+description: Rancher logging helm chart to support logging function in rancher
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+name: rancher-logging
+version: 0.2.2
+appVersion: 1.6.3
+home: https://www.fluentd.org/
+sources:
+- https://www.fluentd.org/
+maintainers:
+- name: Michelia
+  email: support@rancher.com

--- a/charts/rancher-logging/0.2.3/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Rancher logging helm chart to support logging function in rancher
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: rancher-logging
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.6.3
 home: https://www.fluentd.org/
 sources:

--- a/charts/rancher-logging/0.2.3/README.md
+++ b/charts/rancher-logging/0.2.3/README.md
@@ -1,0 +1,11 @@
+# Rancher Logging
+
+* Installs [Fluentd](https://www.fluentd.org/) and flexvolume log driver to collect container logs in Rancher
+
+## Introduction
+
+This chart bootstraps a [Fluentd](https://www.fluentd.org/) daemonset and a [Log-Aggregator](https://github.com/rancher/log-aggregator) flexvolume on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+It's use for sends logs to log target config in rancher.
+
+## Prerequisites
+  - Rancher 2.1+

--- a/charts/rancher-logging/0.2.3/app-readme.md
+++ b/charts/rancher-logging/0.2.3/app-readme.md
@@ -1,0 +1,8 @@
+# Rancher Logging
+
+* Installs [Fluentd](https://www.fluentd.org/) and flexvolume log driver to collect container logs in Rancher
+
+## Changelog
+
+* 0.1.5
+    * Added option `global.privileged` to enable the privileged securityContext in logging containers. This is needed when running SELinux enabled Docker on the host(s).

--- a/charts/rancher-logging/0.2.3/charts/fluentd-tester/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd-tester/Chart.yaml
@@ -1,0 +1,16 @@
+name: fluentd-tester
+version: 0.0.2
+appVersion: 1.6.3
+home: https://www.fluentd.org/
+description: A Fluentd Test Helm chart for validate fluentd config
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- rancher
+- logging
+sources:
+- https://github.com/helm/charts/stable/fluentd-elasticsearch
+maintainers:
+- name: michelia
+  email: support@rancher.com
+engine: gotpl

--- a/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/_helpers.tpl
+++ b/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd-tester.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fluentd-tester.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fluentd-tester.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "fluentd-tester.version" -}}
+{{- $name := include "fluentd-tester.name" . -}}
+{{- $version := .Chart.Version | replace "+" "_" -}}
+{{- printf "%s-%s" $name $version -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fluentd-tester.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "fluentd-tester.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/clusterrole.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: {{ template "rbac_api_version" . }}
+metadata:
+  name: {{ template "fluentd-tester.fullname" . }}
+  labels:
+    app: {{ template "fluentd-tester.name" . }}
+    chart: {{ template "fluentd-tester.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  - "pods"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/clusterrolebinding.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac_api_version" . }}
+metadata:
+  name: {{ template "fluentd-tester.fullname" . }}
+  labels:
+    app: {{ template "fluentd-tester.name" . }}
+    chart: {{ template "fluentd-tester.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd-tester.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fluentd-tester.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/deployment.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: {{ template "deployment_api_version" . }}
+kind: Deployment
+metadata:
+  name: {{ template "fluentd-tester.fullname" . }}
+  labels:
+    app: {{ template "fluentd-tester.name" . }}
+    chart: {{ template "fluentd-tester.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "fluentd-tester.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fluentd-tester.name" . }}
+        chart: {{ template "fluentd-tester.version" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    {{- if .Values.labels }}
+    {{ toYaml .Values.labels | indent 4 }}
+    {{- end }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "fluentd-tester.fullname" . }}
+      containers:
+      - name: "dry-run"
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        {{- if .Values.command }}
+        command: {{ .Values.command }}
+        {{ end }}
+        env:
+        {{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.service }}
+        ports:
+{{- range $port := .Values.service.ports }}
+          - name: {{ $port.name }}
+            containerPort: {{ $port.port }}
+{{- if $port.protocol }}
+            protocol: {{ $port.protocol }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+      nodeSelector:
+{{- include "linux-node-selector" . | nindent 8 }}
+{{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}

--- a/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/service-account.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd-tester/templates/service-account.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fluentd-tester.fullname" . }}
+  labels:
+    app: {{ template "fluentd-tester.name" . }}
+    chart: {{ template "fluentd-tester.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/fluentd-tester/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd-tester/values.yaml
@@ -1,0 +1,34 @@
+labels: {}
+
+image:
+  repository: rancher/fluentd
+  tag: v0.1.19
+  pullPolicy: IfNotPresent
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 500Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 200Mi
+# env:
+
+command: '["sh", "-c", "tail -f /dev/null"]'
+
+rbac:
+  create: true
+
+serviceAccount:
+  create: true
+
+annotations: {}
+
+# updateStrategy:
+#   type: RollingUpdate
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+nodeSelector: {}

--- a/charts/rancher-logging/0.2.3/charts/fluentd-tester/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd-tester/values.yaml
@@ -2,7 +2,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.19
+  tag: v0.1.22
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/Chart.yaml
@@ -1,0 +1,16 @@
+name: fluentd
+version: 0.0.2
+appVersion: 1.6.3
+home: https://www.fluentd.org/
+description: A Fluentd Helm chart for Rancher system logging
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- rancher
+- logging
+sources:
+- https://github.com/helm/charts/stable/fluentd-elasticsearch
+maintainers:
+- name: michelia
+  email: support@rancher.com
+engine: gotpl

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/Chart.yaml
@@ -1,0 +1,17 @@
+name: fluentd-linux
+version: 0.0.2
+appVersion: 1.6.3
+home: https://www.fluentd.org/
+description: A Fluentd Helm chart for Rancher system logging
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- rancher
+- logging
+- linux
+sources:
+- https://github.com/helm/charts/stable/fluentd-elasticsearch
+maintainers:
+- name: michelia
+  email: support@rancher.com
+engine: gotpl

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/templates/daemonset.yaml
@@ -1,0 +1,195 @@
+apiVersion: {{ template "daemonset_api_version" . }}
+kind: DaemonSet
+metadata:
+  name: {{ template "fluentd.fullname" . }}-linux
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "fluentd.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fluentd.name" . }}
+        chart: {{ template "fluentd.version" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    {{- if .Values.labels }}
+    {{ toYaml .Values.labels | indent 4 }}
+    {{- end }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "fluentd.fullname" . }}
+      containers:
+      - name: {{ template "fluentd.fullname" . }}
+        image:  {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+{{- if .Values.global.privileged }}
+        securityContext:
+          privileged: true
+{{- end }}
+        {{- if .Values.command }}
+        command: {{ .Values.command }}
+        {{ end }}
+        env:
+        {{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - mountPath: /fluentd/etc/config/custom
+          name: custom
+        - mountPath: /fluentd/etc/config/precan
+          name: config
+        - mountPath: /fluentd/etc/config/entry
+          name: entry
+        - mountPath: /fluentd/etc/config/ssl
+          name: ssl
+        - mountPath: {{ .Values.cluster.dockerRoot }}
+          name: dockerroot
+        - mountPath: /var/log/containers
+          name: varlogcontainers
+        - mountPath: /var/log/pods
+          name: varlogpods
+        - mountPath: /var/lib/rancher/rke/log
+          name: rkelog
+        - mountPath: /var/lib/rancher/log-volumes
+          name: customlog
+        - mountPath: /fluentd/log
+          name: fluentdlog
+        - name: libsystemddir
+          mountPath: /host/lib
+          readOnly: true
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+        ports:
+{{- range $port := .Values.service.ports }}
+          - name: {{ $port.name }}
+            containerPort: {{ $port.port }}
+{{- if $port.protocol }}
+            protocol: {{ $port.protocol }}
+{{- end }}
+{{- end }}
+{{- if .Values.livenessProbe.enabled }}
+        # Liveness probe is aimed to help in situarions where fluentd
+        # silently hangs for no apparent reasons until manual restart.
+        # The idea of this probe is that if fluentd is not queueing or
+        # flushing chunks for 5 minutes, something is not right. If
+        # you want to change the fluentd configuration, reducing amount of
+        # logs fluentd collects, consider changing the threshold or turning
+        # liveness probe off completely.
+        livenessProbe:
+          initialDelaySeconds: 600
+          periodSeconds: 60
+          exec:
+            command:
+            - '/bin/sh'
+            - '-c'
+            - >
+              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+              STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
+              if [ ! -e /fluentd/log/buffer ];
+              then
+                exit 1;
+              fi;
+              touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
+              if [[ -z "$(find /fluentd/log/buffer -type f -newer /tmp/marker-stuck -print -quit)" ]];
+              then
+                rm -rf /fluentd/log/buffer;
+                exit 1;
+              fi;
+              touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
+              if [[ -z "$(find /fluentd/log/buffer -type f -newer /tmp/marker-liveness -print -quit)" ]];
+              then
+                exit 1;
+              fi;
+{{- end }}
+      - name: {{ template "fluentd.fullname" . }}-{{ .Values.configmapReload.name }}
+        image: {{ template "system_default_registry" . }}{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}
+        imagePullPolicy: "{{ .Values.configmapReload.image.pullPolicy }}"
+        args:
+          - --volume-dir=/fluentd/etc/config/custom
+          - --volume-dir=/fluentd/etc/config/precan
+          - --volume-dir=/fluentd/etc/config/ssl
+          - --volume-dir=/fluentd/etc/config/entry
+          - --webhook-method=GET
+          - --webhook-url=http://127.0.0.1:24444/api/config.reload
+        resources:
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
+        volumeMounts:
+          - mountPath: /fluentd/etc/config/custom
+            name: custom
+          - mountPath: /fluentd/etc/config/precan
+            name: config
+          - mountPath: /fluentd/etc/config/entry
+            name: entry
+          - mountPath: /fluentd/etc/config/ssl
+            name: ssl
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /var/lib/rancher/fluentd/etc/config/custom
+        name: custom
+      - hostPath:
+          path: {{ .Values.cluster.dockerRoot }}
+        name: dockerroot
+      - hostPath:
+          path: /var/log/containers
+        name: varlogcontainers
+      - hostPath:
+          path: /var/log/pods
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/rancher/rke/log
+        name: rkelog
+      - hostPath:
+          path: /var/lib/rancher/log-volumes
+        name: customlog
+      - hostPath:
+          path: /var/lib/rancher/fluentd/log
+        name: fluentdlog
+      - name: config
+        secret:
+          secretName: {{ template "fluentd.fullname" . }}
+      - name: entry
+        secret:
+          secretName: {{ template "fluentd.fullname" . }}-entry
+      - name: ssl
+        secret:
+          secretName: {{ template "fluentd.fullname" . }}-ssl
+      - name: libsystemddir
+        hostPath:
+          path: /usr/lib64
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+      nodeSelector:
+{{- include "linux-node-selector" . | nindent 8 }}
+{{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/values.yaml
@@ -1,0 +1,56 @@
+nameOverride: fluentd
+labels: {}
+
+image:
+  repository: rancher/fluentd
+  tag: v0.1.19
+  pullPolicy: IfNotPresent
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 500Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 200Mi
+# env:
+
+command: '["fluentd", "-c", "/fluentd/etc/config/entry/fluent.conf"]'
+
+livenessProbe:
+  enabled: true
+
+annotations: {}
+
+# updateStrategy:
+#   type: RollingUpdate
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+nodeSelector: {}
+
+service:
+  type: ClusterIP
+  ports:
+    - name: metric
+      port: 24231
+      targetPort: metric
+
+cluster:
+  dockerRoot: /var/lib/docker
+
+service:
+  ports:
+    - name: metric
+      port: 24231
+      targetPort: metric
+
+configmapReload:
+  name: reloader
+  image:
+    repository: rancher/configmap-reload
+    tag: v0.3.0-rancher2
+    pullPolicy: IfNotPresent
+  resources: {}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/values.yaml
@@ -3,7 +3,7 @@ labels: {}
 
 image:
   repository: rancher/fluentd
-  tag: v0.1.19
+  tag: v0.1.22
   pullPolicy: IfNotPresent
 
 resources: {}
@@ -51,6 +51,6 @@ configmapReload:
   name: reloader
   image:
     repository: rancher/configmap-reload
-    tag: v0.3.0-rancher2
+    tag: v0.3.0-rancher3
     pullPolicy: IfNotPresent
   resources: {}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/Chart.yaml
@@ -1,0 +1,17 @@
+name: fluentd-windows
+version: 0.0.1
+appVersion: 1.6.3
+home: https://www.fluentd.org/
+description: A Fluentd Helm chart for Rancher system logging
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- rancher
+- logging
+- windows
+sources:
+- https://github.com/helm/charts/stable/fluentd-elasticsearch
+maintainers:
+- name: michelia
+  email: support@rancher.com
+engine: gotpl

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
@@ -1,0 +1,166 @@
+{{- if .Values.enabled -}}
+apiVersion: {{ template "daemonset_api_version" . }}
+kind: DaemonSet
+metadata:
+  name: {{ template "fluentd.fullname" . }}-windows
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "fluentd.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fluentd.name" . }}
+        chart: {{ template "fluentd.version" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    {{- if .Values.labels }}
+    {{ toYaml .Values.labels | indent 4 }}
+    {{- end }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "fluentd.fullname" . }}
+      initContainers:
+      - name: init-{{ template "fluentd.fullname" . }}
+        image:  {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        command:
+          - 'powershell'
+          - '-command'
+          - 'New-Item -ItemType Directory -Force -Path /var/lib/rancher/fluentd/log'
+        volumeMounts:
+        - mountPath: /var/lib/rancher
+          name: rancher
+      containers:
+      - name: {{ template "fluentd.fullname" . }}
+        image:  {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        {{- if .Values.command }}
+        command: {{ .Values.command }}
+        {{ end }}
+        env:
+        {{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - mountPath: /fluentd/etc/config/precan
+          name: config
+        - mountPath: /fluentd/etc/config/entry
+          name: entry
+        - mountPath: /fluentd/etc/config/ssl
+          name: ssl
+        - mountPath: {{ .Values.cluster.dockerRoot }}
+          name: dockerroot
+        - mountPath: /var/log/containers
+          name: varlogcontainers
+        - mountPath: /var/log/pods
+          name: varlogpods
+        - mountPath: /var/lib/rancher/rke/log
+          name: rkelog
+        - mountPath: /fluentd/log
+          name: fluentdlog
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+        ports:
+{{- range $port := .Values.service.ports }}
+          - name: {{ $port.name }}
+            containerPort: {{ $port.port }}
+{{- if $port.protocol }}
+            protocol: {{ $port.protocol }}
+{{- end }}
+{{- end }}
+{{- if .Values.livenessProbe.enabled }}
+        # use metrics endpoint to monitor liveness
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 24231
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 3
+          failureThreshold: 3
+          successThreshold: 1
+{{- end }}
+      - name: {{ template "fluentd.fullname" . }}-{{ .Values.configmapReload.name }}
+        image: {{ template "system_default_registry" . }}{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}
+        imagePullPolicy: "{{ .Values.configmapReload.image.pullPolicy }}"
+        args:
+          - --volume-dir=/fluentd/etc/config/precan
+          - --volume-dir=/fluentd/etc/config/ssl
+          - --volume-dir=/fluentd/etc/config/entry
+          - --webhook-method=GET
+          - --webhook-url=http://127.0.0.1:24444/api/config.reload
+        resources:
+{{ toYaml .Values.configmapReload.resources | indent 10 }}
+        volumeMounts:
+          - mountPath: /fluentd/etc/config/precan
+            name: config
+          - mountPath: /fluentd/etc/config/entry
+            name: entry
+          - mountPath: /fluentd/etc/config/ssl
+            name: ssl
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: {{ .Values.cluster.dockerRoot }}
+        name: dockerroot
+      - hostPath:
+          path: /var/log/containers
+        name: varlogcontainers
+      - hostPath:
+          path: /var/log/pods
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/rancher/rke/log
+        name: rkelog
+      - hostPath:
+          path: /var/lib/rancher/fluentd/log
+        name: fluentdlog
+      - hostPath:
+          path: /var/lib/rancher
+        name: rancher
+      - name: config
+        secret:
+          secretName: {{ template "fluentd.fullname" . }}
+      - name: entry
+        secret:
+          secretName: {{ template "fluentd.fullname" . }}-entry
+      - name: ssl
+        secret:
+          secretName: {{ template "fluentd.fullname" . }}-ssl
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+      nodeSelector:
+{{- include "windows-node-selector" . | nindent 8 }}
+{{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/templates/daemonset.yaml
@@ -35,16 +35,6 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "fluentd.fullname" . }}
-      initContainers:
-      - name: init-{{ template "fluentd.fullname" . }}
-        image:  {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
-        command:
-          - 'powershell'
-          - '-command'
-          - 'New-Item -ItemType Directory -Force -Path /var/lib/rancher/fluentd/log'
-        volumeMounts:
-        - mountPath: /var/lib/rancher
-          name: rancher
       containers:
       - name: {{ template "fluentd.fullname" . }}
         image:  {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -126,21 +116,27 @@ spec:
       volumes:
       - hostPath:
           path: {{ .Values.cluster.dockerRoot }}
+          type: DirectoryOrCreate
         name: dockerroot
       - hostPath:
           path: /var/log/containers
+          type: DirectoryOrCreate
         name: varlogcontainers
       - hostPath:
           path: /var/log/pods
+          type: DirectoryOrCreate
         name: varlogpods
       - hostPath:
           path: /var/lib/rancher/rke/log
+          type: DirectoryOrCreate
         name: rkelog
       - hostPath:
           path: /var/lib/rancher/fluentd/log
+          type: DirectoryOrCreate
         name: fluentdlog
       - hostPath:
           path: /var/lib/rancher
+          type: DirectoryOrCreate
         name: rancher
       - name: config
         secret:

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/values.yaml
@@ -1,0 +1,52 @@
+nameOverride: fluentd
+labels: {}
+
+image:
+  os: windows
+  repository: rancher/fluentd
+  tag: v0.1.19
+  pullPolicy: IfNotPresent
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 500Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 200Mi
+# env:
+
+command: '["powershell", "-command",  "fluentd", "-c", "/fluentd/etc/config/entry/fluent.conf"]'
+
+livenessProbe:
+  enabled: true
+
+annotations: {}
+
+# updateStrategy:
+#   type: RollingUpdate
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+
+nodeSelector: {}
+
+cluster:
+  dockerRoot: C:\ProgramData\docker
+
+service:
+  ports:
+    - name: metric
+      port: 24231
+      targetPort: metric
+
+configmapReload:
+  name: reloader
+  image:
+    os: windows
+    repository: rancher/configmap-reload
+    tag: v0.3.0-rancher2
+    pullPolicy: IfNotPresent
+  resources: {}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/values.yaml
@@ -4,7 +4,7 @@ labels: {}
 image:
   os: windows
   repository: rancher/fluentd
-  tag: v0.1.19
+  tag: v0.1.22
   pullPolicy: IfNotPresent
 
 resources: {}
@@ -47,6 +47,6 @@ configmapReload:
   image:
     os: windows
     repository: rancher/configmap-reload
-    tag: v0.3.0-rancher2
+    tag: v0.3.0-rancher3
     pullPolicy: IfNotPresent
   resources: {}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/requirements.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/requirements.yaml
@@ -1,0 +1,10 @@
+dependencies:
+  - name: fluentd-linux
+    version: 0.0.2
+    condition: fluentd.fluentd-linux.enabled
+    repository: "file://./charts/fluentd-linux"
+  
+  - name: fluentd-windows
+    version: 0.0.1
+    condition: fluentd.fluentd-windows.enabled
+    repository: "file://./charts/fluentd-windows"

--- a/charts/rancher-logging/0.2.3/charts/fluentd/templates/_helpers.tpl
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fluentd.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fluentd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "fluentd.version" -}}
+{{- $name := include "fluentd.name" . -}}
+{{- $version := .Chart.Version | replace "+" "_" -}}
+{{- printf "%s-%s" $name $version -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fluentd.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "fluentd.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/templates/rbac.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/templates/rbac.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: {{ template "rbac_api_version" . }}
+metadata:
+  name: {{ template "fluentd.fullname" . }}
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  - "pods"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac_api_version" . }}
+metadata:
+  name: {{ template "fluentd.fullname" . }}
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fluentd.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- if .Values.global.podSecurityPolicy.enabled }}
+---
+kind: Role
+apiVersion: {{ template "rbac_api_version" . }}
+metadata:
+  name: {{ template "fluentd.fullname" . }}-psp-role
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - "policy"
+  resources:
+  - "podsecuritypolicies"
+  resourceNames:
+  - {{ .Release.Name }}-psp
+  verbs:
+  - "use"
+---
+kind: RoleBinding
+apiVersion: {{ template "rbac_api_version" . }}
+metadata:
+  name: {{ template "fluentd.fullname" . }}-psp-rolebinding
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ template "fluentd.fullname" . }}-psp-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/templates/secret.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/templates/secret.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fluentd.fullname" . }}
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+{{- range $key, $value := .Values.secrets.config }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fluentd.fullname" . }}-entry
+  labels:
+    app: {{ template "fluentd.name" . }}-entry
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
+type: Opaque
+data:
+{{- range $key, $value := .Values.secrets.entry }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fluentd.fullname" . }}-ssl
+  labels:
+    app: {{ template "fluentd.name" . }}-ssl
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
+type: Opaque

--- a/charts/rancher-logging/0.2.3/charts/fluentd/templates/service-account.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/templates/service-account.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fluentd.fullname" . }}
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/templates/service.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/templates/service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.service }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fluentd.fullname" . }}
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  {{- range $port := .Values.service.ports }}
+    - name: {{ $port.name }}
+      port: {{ $port.port }}
+      targetPort: {{ $port.port }}
+      {{- if $port.nodePort }}
+      nodePort: {{ $port.nodePort }}
+      {{- end }}
+      {{- if $port.protocol }}
+      protocol: {{ $port.protocol }}
+      {{- end }}
+  {{- end }}
+  selector:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.version" . }}
+{{- end }}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/values.yaml
@@ -1,0 +1,401 @@
+fluentd-linux:
+  enabled: true
+
+fluentd-windows:
+  enabled: false
+
+nameOverride: fluentd
+
+rbac:
+  create: true
+
+serviceAccount:
+  create: true
+
+service:
+  type: ClusterIP
+  ports:
+    - name: metric
+      port: 24231
+      targetPort: metric
+
+secrets:
+  entry:
+    fluent.conf: |-
+      @include /fluentd/etc/config/precan/*.conf
+
+      @include /fluentd/etc/config/custom/project/*.conf
+      @include /fluentd/etc/config/custom/cluster/*.conf
+  config:
+    system.conf: |-
+      <source>
+        @type prometheus
+        bind 0.0.0.0
+        port 24231
+        metrics_path /metrics
+      </source>
+
+      <source>
+        @type prometheus_output_monitor
+        interval 10
+        <labels>
+          pod_name ${hostname}
+        </labels>
+      </source>
+
+      <system>
+        rpc_endpoint 127.0.0.1:24444
+      </system>
+    custom_cluster.conf: |-
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/apache2/*/*
+        pos_file /fluentd/log/custom_cluster_apache2_new.log.pos
+        tag tmp-cluster-custom.*
+        format /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)?$/ 
+        time_format %d/%b/%Y:%H:%M:%S %z
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/nginx/*/* 
+        pos_file /fluentd/log/custom_cluster_nginx_new.log.pos
+        tag tmp-cluster-custom.*
+        format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)") (?<gzip_ratio>[^ ]*)?$/
+        time_format %d/%b/%Y:%H:%M:%S %z
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/rfc3164/*/*
+        pos_file /fluentd/log/custom_cluster_rfc3164_new.log.pos
+        tag tmp-cluster-custom.*
+        format /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+        time_format "%b %d %H:%M:%S"
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/rfc5424/*/*
+        pos_file /fluentd/log/custom_cluster_rfc5424_new.log.pos
+        tag tmp-cluster-custom.*
+        format /\A^\<(?<pri>[0-9]{1,3})\>[1-9]\d{0,2} (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|[^ ])) (?<message>.+)$\z/
+        time_format "%Y-%m-%dT%H:%M:%S.%L%z"
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/json/*/*
+        pos_file /fluentd/log/custom_cluster_json_new.log.pos
+        tag tmp-cluster-custom.*
+        format json
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/none/*/*
+        pos_file /fluentd/log/custom_cluster_none_new.log.pos
+        tag tmp-cluster-custom.*
+        <parse>
+          @type none
+          message_key log
+        </parse>
+      </source>
+
+      <filter tmp-cluster-custom.**>
+        @type record_transformer
+        enable_ruby true  
+        <record>
+          tag ${tag}
+          cluster_id ${component = tag.match(Regexp.compile('tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<pod_id>[^_]+)_(?<volume_name>[^_]+)\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])+)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['cluster_id']}
+          cluster_name ${component = tag.match(Regexp.compile('tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<pod_id>[^_]+)_(?<volume_name>[^_]+)\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])+)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['cluster_name']}
+          project_id ${component = tag.match(Regexp.compile('tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<pod_id>[^_]+)_(?<volume_name>[^_]+)\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])+)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['project_id']}
+          project_name ${component = tag.match(Regexp.compile('tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<pod_id>[^_]+)_(?<volume_name>[^_]+)\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])+)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['project_name'].gsub('~', '_')}
+          workload_name ${component = tag.match(Regexp.compile('tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<pod_id>[^_]+)_(?<volume_name>[^_]+)\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])+)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['workload_name']}
+          volume_name ${component = tag.match(Regexp.compile('tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<pod_id>[^_]+)_(?<volume_name>[^_]+)\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])+)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['volume_name']}
+          filename ${component = tag.match(Regexp.compile('tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<pod_id>[^_]+)_(?<volume_name>[^_]+)\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])+)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['filename']}
+          format ${component = tag.match(Regexp.compile('tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<pod_id>[^_]+)_(?<volume_name>[^_]+)\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])+)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['format']}
+        </record>
+      </filter>
+
+      <match tmp-cluster-custom.**>
+        @type rewrite_tag_filter
+        <rule>
+          key     tag
+          pattern tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)
+          tag     tmp1.cluster-custom.$10_$6_$10_$11
+        </rule>
+      </match>
+
+      <filter tmp1.cluster-custom.**>
+        @type kubernetes_metadata 
+        tag_to_kubernetes_name_regexp tmp1\.cluster-custom\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<docker_id>.+)_(?<container_name>.+)$
+      </filter>
+
+      <match tmp1.cluster-custom.**>
+        @type rewrite_tag_filter
+        remove_tag_prefix tmp1
+        <rule>
+          key     tag
+          pattern tmp-cluster-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)
+          tag     cluster-custom
+        </rule>
+      </match>
+
+      <filter cluster-custom.**>
+        @type record_transformer
+        enable_ruby
+        remove_keys tag
+      </filter>
+    custom_project.conf: |-
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/apache2/*/*
+        pos_file /fluentd/log/custom_project_apache2_new.log.pos
+        tag tmp-project-custom.*
+        format /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)?$/ 
+        time_format %d/%b/%Y:%H:%M:%S %z
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/nginx/*/* 
+        pos_file /fluentd/log/custom_project_nginx_new.log.pos
+        tag tmp-project-custom.*
+        format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)") (?<gzip_ratio>[^ ]*)?$/
+        time_format %d/%b/%Y:%H:%M:%S %z
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/rfc3164/*/*
+        pos_file /fluentd/log/custom_project_rfc3164_new.log.pos
+        tag tmp-project-custom.*
+        format /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+        time_format "%b %d %H:%M:%S"
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/rfc5424/*/*
+        pos_file /fluentd/log/custom_project_rfc5424_new.log.pos
+        tag tmp-project-custom.*
+        format /\A^\<(?<pri>[0-9]{1,3})\>[1-9]\d{0,2} (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|[^ ])) (?<message>.+)$\z/
+        time_format "%Y-%m-%dT%H:%M:%S.%L%z"
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/json/*/*
+        pos_file /fluentd/log/custom_project_json_new.log.pos
+        tag tmp-project-custom.*
+        format json
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/*/none/*/*
+        pos_file /fluentd/log/custom_project_none_new.log.pos
+        tag tmp-project-custom.*
+        <parse>
+          @type none
+          message_key log
+        </parse>
+      </source>
+
+      <filter tmp-project-custom.**>
+        @type record_transformer
+        enable_ruby true  
+        <record>
+          tag ${tag}
+          cluster_id ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['cluster_id']}
+          cluster_name ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['cluster_name']}
+          project_id ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['project_id']}
+          project_name ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['project_name'].gsub('~', '_')}
+          workload_name ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['workload_name']}
+          volume_name ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['volume_name']}
+          filename ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['filename']}
+          format ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); component['format']}
+          cluster_project ${component = tag.match(Regexp.compile('tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)')); "#{component['cluster_id']}:#{component['project_id']}"}
+        </record>
+      </filter>
+
+      <match tmp-project-custom.**>
+        @type rewrite_tag_filter
+        <rule>
+          key     tag
+          pattern tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)
+          tag     tmp1.tmp2-project-custom.$10_$6_$10_$11
+        </rule>
+      </match>
+
+      <filter tmp1.tmp2-project-custom.**>
+        @type kubernetes_metadata 
+        tag_to_kubernetes_name_regexp tmp1\.tmp2-project-custom\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<docker_id>.+)_(?<container_name>.+)$
+      </filter>
+
+      <match tmp1.tmp2-project-custom.**>
+        @type rewrite_tag_filter
+        remove_tag_prefix tmp1
+        <rule>
+          key     tag
+          pattern tmp-project-custom\.var\.lib\.rancher\.log-volumes\.((?<pod_id>[^_]+)_(?<volume_name>[^_]+))\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])*)_(?<container_name>[^_^.]+)\.(?<filename>.+)
+          tag     tmp2-project-custom
+        </rule>
+      </match>
+
+      <match tmp2-project-custom.**>
+        @type rewrite_tag_filter
+        <rule>
+          key cluster_project
+          pattern (?<cluster_project>.+\:.+)
+          tag project-custom.$1
+        </rule>
+      </match>
+
+      <filter project-custom.**>
+        @type record_transformer
+        enable_ruby
+        remove_keys docker,tag
+      </filter>
+    legacy_custom_cluster.conf: |-
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/apache2/*/*
+        pos_file /fluentd/log/custom_cluster_apache2.log.pos
+        tag tmp2.cluster-custom.*
+        format /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)?$/ 
+        time_format %d/%b/%Y:%H:%M:%S %z
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/nginx/*/* 
+        pos_file /fluentd/log/custom_cluster_nginx.log.pos
+        tag tmp2.cluster-custom.*
+        format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)") (?<gzip_ratio>[^ ]*)?$/
+        time_format %d/%b/%Y:%H:%M:%S %z
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/rfc3164/*/*
+        pos_file /fluentd/log/custom_cluster_rfc3164.log.pos
+        tag tmp2.cluster-custom.*
+        format /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+        time_format "%b %d %H:%M:%S"
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/rfc5424/*/*
+        pos_file /fluentd/log/custom_cluster_rfc5424.log.pos
+        tag tmp2.cluster-custom.*
+        format /\A^\<(?<pri>[0-9]{1,3})\>[1-9]\d{0,2} (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|[^ ])) (?<message>.+)$\z/
+        time_format "%Y-%m-%dT%H:%M:%S.%L%z"
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/json/*/*
+        pos_file /fluentd/log/custom_cluster_json.log.pos
+        tag tmp2.cluster-custom.*
+        format json
+      </source>
+
+      <filter tmp2.cluster-custom.**>
+        @type record_transformer
+        enable_ruby true  
+        <record>
+          tag ${tag}    
+          cluster_id ${component = tag.match(Regexp.compile('tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$'));component['cluster_id']}
+          cluster_name ${component = tag.match(Regexp.compile('tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['cluster_name']}
+          project_id ${component = tag.match(Regexp.compile('tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['project_id']}
+          project_name ${component = tag.match(Regexp.compile('tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['project_name'].gsub('~', '_')}
+          workload_name ${component = tag.match(Regexp.compile('tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['workload_name']}
+          volume_name ${component = tag.match(Regexp.compile('tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['volume_name']}
+          filename ${component = tag.match(Regexp.compile('tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['filename']}
+          format ${component = tag.match(Regexp.compile('tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['format']}
+        </record>
+      </filter>
+
+      <match tmp2.cluster-custom.**>
+        @type rewrite_tag_filter
+        remove_tag_prefix tmp2
+        <rule>
+          key     tag
+          pattern tmp2\.cluster-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$
+          tag     cluster-custom
+        </rule>
+      </match>
+    legacy_custom_project.conf: |-
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/apache2/*/*
+        pos_file /fluentd/log/custom_project_apache2.log.pos
+        tag tmp2.tmp2-project-custom.*
+        format /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)?$/ 
+        time_format %d/%b/%Y:%H:%M:%S %z
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/nginx/*/* 
+        pos_file /fluentd/log/custom_project_nginx.log.pos
+        tag tmp2.tmp2-project-custom.*
+        format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)") (?<gzip_ratio>[^ ]*)?$/
+        time_format %d/%b/%Y:%H:%M:%S %z
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/rfc3164/*/*
+        pos_file /fluentd/log/custom_project_rfc3164.log.pos
+        tag tmp2.tmp2-project-custom.*
+        format /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+        time_format "%b %d %H:%M:%S"
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/rfc5424/*/*
+        pos_file /fluentd/log/custom_project_rfc5424.log.pos
+        tag tmp2.tmp2-project-custom.*
+        format /\A^\<(?<pri>[0-9]{1,3})\>[1-9]\d{0,2} (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|[^ ])) (?<message>.+)$\z/
+        time_format "%Y-%m-%dT%H:%M:%S.%L%z"
+      </source>
+
+      <source>
+        @type tail
+        path /var/lib/rancher/log-volumes/json/*/*
+        pos_file /fluentd/log/custom_project_json.log.pos
+        tag tmp2.tmp2-project-custom.*
+        format json
+      </source>
+
+      <filter tmp2.tmp2-project-custom.**>
+        @type record_transformer
+        enable_ruby true  
+        <record>
+          tag ${tag}        
+          cluster_id ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['cluster_id']}
+          cluster_name ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['cluster_name']}
+          project_id ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['project_id']}
+          project_name ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['project_name']}
+          workload_name ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['workload_name']}
+          volume_name ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['volume_name']}
+          filename ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['filename']}
+          format ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); component['format']}
+          cluster_project ${component = tag.match(Regexp.compile('tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>.+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$')); "#{component['cluster_id']}:#{component['project_id']}"}
+        </record>
+      </filter>
+
+      <match tmp2.tmp2-project-custom.**>
+        @type rewrite_tag_filter
+        remove_tag_prefix tmp2
+        <rule>
+          key     tag
+          pattern tmp2\.tmp2-project-custom\.var\.lib\.rancher\.log-volumes\.(?<format>[a-z0-9]+)\.(?<cluster_id>[^_]+)_(?<cluster_name>[^_]+)_(?<namespace>[^_]+)_(?<project_id>[^_]+)_(?<project_name>[^_]+)_(?<workload_name>[^_]+)_(?<container_name>[^_]+)_(?<volume_name>[^_^.]+)\.(?<filename>.+)$
+          tag     tmp2-project-custom
+        </rule>
+      </match>

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/Chart.yaml
@@ -1,0 +1,14 @@
+name: log-aggregator
+version: 0.0.2
+appVersion: 0.1.5
+home: https://github.com/rancher/log-aggregator
+description: Deploy flexvolume driver log-aggregator to collect log.
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- flexvolume driver
+- logging
+maintainers:
+- name: michelia
+  email: support@rancher.com
+engine: gotpl

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-linux/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-linux/Chart.yaml
@@ -1,0 +1,15 @@
+name: log-aggregator-linux
+version: 0.0.1
+appVersion: 0.1.5
+home: https://github.com/rancher/log-aggregator
+description: Deploy flexvolume driver log-aggregator to collect log.
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- flexvolume driver
+- logging
+- linux
+maintainers:
+- name: michelia
+  email: support@rancher.com
+engine: gotpl

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-linux/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-linux/templates/daemonset.yaml
@@ -1,0 +1,60 @@
+apiVersion: {{ template "daemonset_api_version" . }}
+kind: DaemonSet
+metadata:
+  name: {{ template "log-aggregator.fullname" . }}-linux
+  labels:
+    app: {{ template "log-aggregator.name" . }}
+    chart: {{ template "log-aggregator.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "log-aggregator.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "log-aggregator.name" . }}
+        chart: {{ template "log-aggregator.version" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "log-aggregator.fullname" . }}
+      containers:
+      - name: log-aggregator
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+{{- if .Values.global.privileged }}
+        securityContext:
+          privileged: true
+{{- end }}
+        volumeMounts:
+        - name: flexvolume-driver
+          mountPath: /flexmnt
+{{- if .Values.env }}
+        env:
+{{ toYaml .Values.env | indent 10 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      terminationGracePeriodSeconds: 10
+      nodeSelector:
+{{- include "linux-node-selector" . | nindent 8 }}
+    {{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+    {{- if .Values.tolerations }}
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: flexvolume-driver
+        hostPath:
+          path: {{ .Values.flexVolumeDir }}

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-linux/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-linux/values.yaml
@@ -1,0 +1,27 @@
+nameOverride: log-aggregator
+
+labels: {}
+## Log Aggregator container image
+##
+image:
+  repository: rancher/log-aggregator
+  tag: v0.1.7
+
+nodeSelector: {}
+
+# updateStrategy:
+#   type: RollingUpdate
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+## Resource limits & requests
+## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+  # requests:
+  #   memory: 400Mi
+
+## flexvolume dir
+flexVolumeDir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-windows/Chart.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-windows/Chart.yaml
@@ -1,0 +1,15 @@
+name: log-aggregator-windows
+version: 0.0.1
+appVersion: 0.1.5
+home: https://github.com/rancher/log-aggregator
+description: Deploy flexvolume driver log-aggregator to collect log.
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- flexvolume driver
+- logging
+- windows
+maintainers:
+- name: michelia
+  email: support@rancher.com
+engine: gotpl

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-windows/templates/daemonset.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-windows/templates/daemonset.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.enabled -}}
+apiVersion: {{ template "daemonset_api_version" . }}
+kind: DaemonSet
+metadata:
+  name: {{ template "log-aggregator.fullname" . }}-windows
+  labels:
+    app: {{ template "log-aggregator.name" . }}
+    chart: {{ template "log-aggregator.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "log-aggregator.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "log-aggregator.name" . }}
+        chart: {{ template "log-aggregator.version" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "log-aggregator.fullname" . }}
+      containers:
+      - name: log-aggregator
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        volumeMounts:
+        - name: flexvolume-driver
+          mountPath: /flexmnt
+{{- if .Values.env }}
+        env:
+{{ toYaml .Values.env | indent 10 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      terminationGracePeriodSeconds: 10
+      nodeSelector:
+{{- include "windows-node-selector" . | nindent 8 }}
+    {{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+    {{- if .Values.tolerations }}
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: flexvolume-driver
+        hostPath:
+          path: {{ .Values.flexVolumeDir }}
+{{- end }}

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-windows/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/charts/log-aggregator-windows/values.yaml
@@ -1,0 +1,27 @@
+nameOverride: log-aggregator
+
+labels: {}
+## Log Aggregator container image
+##
+image:
+  repository: rancher/log-aggregator
+  tag: v0.1.7
+
+nodeSelector: {}
+
+# updateStrategy:
+#   type: RollingUpdate
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+## Resource limits & requests
+## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+  # requests:
+  #   memory: 400Mi
+
+## flexvolume dir
+flexVolumeDir: C:/var/lib/kubelet/volumeplugins

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/requirements.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/requirements.yaml
@@ -1,0 +1,10 @@
+dependencies:
+  - name: log-aggregator-linux
+    version: 0.0.1
+    condition: log-aggregator.log-aggregator-linux.enabled
+    repository: "file://./charts/log-aggregator-linux"
+
+  - name: log-aggregator-windows
+    version: 0.0.1
+    condition: log-aggregator.log-aggregator-windows.enabled
+    repository: "file://./charts/log-aggregator-window"

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/templates/_helpers.tpl
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "log-aggregator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "log-aggregator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "log-aggregator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "log-aggregator.version" -}}
+{{- $name := include "log-aggregator.name" . -}}
+{{- $version := .Chart.Version | replace "+" "_" -}}
+{{- printf "%s-%s" $name $version -}}
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/templates/rbac.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/templates/rbac.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.global.podSecurityPolicy.enabled -}}
+kind: Role
+apiVersion: {{ template "rbac_api_version" . }}
+metadata:
+  name: {{ template "log-aggregator.fullname" . }}-psp-role
+  labels:
+    app: {{ template "log-aggregator.name" . }}
+    chart: {{ template "log-aggregator.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - "policy"
+  resources:
+  - "podsecuritypolicies"
+  resourceNames:
+  - {{ .Release.Name }}-psp
+  verbs:
+  - "use"
+---
+kind: RoleBinding
+apiVersion: {{ template "rbac_api_version" . }}
+metadata:
+  name: {{ template "log-aggregator.fullname" . }}-psp-rolebinding
+  labels:
+    app: {{ template "log-aggregator.name" . }}
+    chart: {{ template "log-aggregator.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "log-aggregator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ template "log-aggregator.fullname" . }}-psp-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/templates/service-account.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/templates/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "log-aggregator.fullname" . }}
+  labels:
+    app: {{ template "log-aggregator.name" . }}
+    chart: {{ template "log-aggregator.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/charts/rancher-logging/0.2.3/charts/log-aggregator/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/log-aggregator/values.yaml
@@ -1,0 +1,5 @@
+log-aggregator-linux:
+  enabled: true
+
+log-aggregator-windows:
+  enabled: false

--- a/charts/rancher-logging/0.2.3/questions.yml
+++ b/charts/rancher-logging/0.2.3/questions.yml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.3.4-rc1

--- a/charts/rancher-logging/0.2.3/requirements.yaml
+++ b/charts/rancher-logging/0.2.3/requirements.yaml
@@ -1,0 +1,15 @@
+dependencies:
+  - name: fluentd
+    version: 0.0.2
+    condition: fluentd.enabled
+    repository: "file://./charts/fluentd/"
+
+  - name: log-aggregator
+    version: 0.0.2
+    condition: log-aggregator.enabled
+    repository: "file://./charts/log-aggregator/"
+
+  - name: fluentd-tester
+    version: 0.0.2
+    condition: fluentd-tester.enabled
+    repository: "file://./charts/fluentd-tester/"

--- a/charts/rancher-logging/0.2.3/templates/_helpers.tpl
+++ b/charts/rancher-logging/0.2.3/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "logging.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "logging.version" -}}
+{{- $name := include "logging.name" . -}}
+{{- $version := .Chart.Version | replace "+" "_" -}}
+{{- printf "%s-%s" $name $version -}}
+{{- end -}}
+
+{{- define "deployment_api_version" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+{{- "apps/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta2" -}}
+{{- "apps/v1beta2" -}}
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta1" -}}
+{{- "apps/v1beta1" -}}
+{{- else -}}
+{{- "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "daemonset_api_version" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+{{- "apps/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta2" -}}
+{{- "apps/v1beta2" -}}
+{{- else -}}
+{{- "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "rbac_api_version" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+{{- "rbac.authorization.k8s.io/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" -}}
+{{- "rbac.authorization.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- "rbac.authorization.k8s.io/v1alpha1" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "linux-node-selector" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+beta.kubernetes.io/os: linux
+{{- else -}}
+kubernetes.io/os: linux
+{{- end -}}
+{{- end -}}
+
+{{- define "windows-node-selector" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+beta.kubernetes.io/os: windows
+{{- else -}}
+kubernetes.io/os: windows
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-logging/0.2.3/templates/psp.yaml
+++ b/charts/rancher-logging/0.2.3/templates/psp.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.global.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-psp
+  labels:
+    app: {{ template "logging.name" . }}
+    chart: {{ template "logging.version" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+{{- if .Values.global.privileged }}
+  privileged: true
+{{- else }}
+  allowPrivilegeEscalation: false
+{{- end }}
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  allowedHostPaths:
+    - pathPrefix: /
+{{- end }}

--- a/charts/rancher-logging/0.2.3/values.yaml
+++ b/charts/rancher-logging/0.2.3/values.yaml
@@ -1,0 +1,11 @@
+fluentd:
+  enabled: false
+fluentd-tester:
+  enabled: false
+log-aggregator:
+  enabled: false
+global:
+  systemDefaultRegistry: ""
+  podSecurityPolicy:
+    enabled: true
+  privileged: false


### PR DESCRIPTION
Relevant issue: https://github.com/rancher/rancher/issues/30279

Notes about this branch (`v2.5-windows-logging-patch`):
* This a beta-testing branch, so it may not be stable
* This branch will not be updated in the future (revert back to `release-v2.5` once a future release contains `7bd7ede9edde24ea506b385667841843fd9aa131`, `c79d8c8f078252f834d829cdf1e11a5bda8d1b1a`, and `d9be87f46687afde98d7ebbc38b63903bace062e`)