### PR TITLE
[2.4] fix istio version display

### DIFF
--- a/charts/rancher-istio/1.5.901/questions.yaml
+++ b/charts/rancher-istio/1.5.901/questions.yaml
@@ -1,3 +1,3 @@
 labels:
-  rancher.istio.v1.5.900: 1.5.9
+  rancher.istio.v1.5.901: 1.5.9
 rancher_min_version: 2.4.5-rc1


### PR DESCRIPTION
#30857

This fixed a minor bug where the istio version was not displayed correctly in the istio version dropdown.