### PR TITLE
moved resources key inside if else block

### DIFF
--- a/charts/rancher-istio/1.5.901/files/injection-template.yaml
+++ b/charts/rancher-istio/1.5.901/files/injection-template.yaml
@@ -370,7 +370,7 @@ containers:
   {{- end }}
 {{- else }}
   {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
+    {{ toYaml .Values.global.proxy.resources | indent 4 }}
   {{- end }}
 {{- end }}
   volumeMounts:


### PR DESCRIPTION
issue: #30921

PROBLEM:
we were getting template errors anytime istio injected a sidecar

SOLUTION:
fixed indentation

TESTING:
kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.4/samples/bookinfo/networking/bookinfo-gateway.yaml -fhttps://raw.githubusercontent.com/istio/istio/release-1.4/samples/bookinfo/platform/kube/bookinfo.yaml

