### PR TITLE
Upgrade eks-operator chart to 1.0.6

### DIFF
--- a/charts/rancher-eks-operator/1.0.600/Chart.yaml
+++ b/charts/rancher-eks-operator/1.0.600/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+name: rancher-eks-operator
+description: A Helm chart for provisioning EKS clusters
+home: https://github.com/rancher/eks-operator
+sources:
+  - "https://github.com/rancher/eks-operator"
+version: 1.0.500
+appVersion: v1.0.5

--- a/charts/rancher-eks-operator/1.0.600/Chart.yaml
+++ b/charts/rancher-eks-operator/1.0.600/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for provisioning EKS clusters
 home: https://github.com/rancher/eks-operator
 sources:
   - "https://github.com/rancher/eks-operator"
-version: 1.0.500
-appVersion: v1.0.5
+version: 1.0.600
+appVersion: v1.0.6-rc1

--- a/charts/rancher-eks-operator/1.0.600/questions.yaml
+++ b/charts/rancher-eks-operator/1.0.600/questions.yaml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.5.0-alpha1

--- a/charts/rancher-eks-operator/1.0.600/templates/NOTES.txt
+++ b/charts/rancher-eks-operator/1.0.600/templates/NOTES.txt
@@ -1,0 +1,4 @@
+You have deployed the Rancher EKS operator
+Version: {{ .Chart.AppVersion }}
+Description: This operator provisions EKS clusters
+from EKSClusterConfig CRs.

--- a/charts/rancher-eks-operator/1.0.600/templates/_helpers.tpl
+++ b/charts/rancher-eks-operator/1.0.600/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-eks-operator/1.0.600/templates/clusterrole.yaml
+++ b/charts/rancher-eks-operator/1.0.600/templates/clusterrole.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eks-operator
+  namespace: cattle-system
+rules:
+  - apiGroups: ['']
+    resources: ['secrets']
+    verbs: ['get', 'list', 'create', 'watch']
+  - apiGroups: ['eks.cattle.io']
+    resources: ['eksclusterconfigs']
+    verbs: ['get', 'list', 'update', 'watch']
+  - apiGroups: ['eks.cattle.io']
+    resources: ['eksclusterconfigs/status']
+    verbs: ['update']

--- a/charts/rancher-eks-operator/1.0.600/templates/clusterrolebinding.yaml
+++ b/charts/rancher-eks-operator/1.0.600/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  eks-operator
+  namespace: cattle-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eks-operator
+subjects:
+- kind: ServiceAccount
+  name: eks-operator
+  namespace: cattle-system

--- a/charts/rancher-eks-operator/1.0.600/templates/deployment.yaml
+++ b/charts/rancher-eks-operator/1.0.600/templates/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eks-config-operator
+  namespace: cattle-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ke.cattle.io/operator: eks
+  template:
+    metadata:
+      labels:
+        ke.cattle.io/operator: eks
+    spec:
+      serviceAccountName: eks-operator
+      containers:
+      - name: eks-operator
+        image: {{ template "system_default_registry" . }}{{ .Values.eksOperator.image.repository }}:{{ .Values.eksOperator.image.tag }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: HTTP_PROXY
+          value: {{ .Values.httpProxy }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.httpsProxy }}
+        - name: NO_PROXY
+          value: {{ .Values.noProxy }}

--- a/charts/rancher-eks-operator/1.0.600/templates/eksclusterconfig.yaml
+++ b/charts/rancher-eks-operator/1.0.600/templates/eksclusterconfig.yaml
@@ -1,0 +1,151 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: eksclusterconfigs.eks.cattle.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: eks.cattle.io
+  names:
+    kind: EKSClusterConfig
+    plural: eksclusterconfigs
+    shortNames:
+    - ekscc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            amazonCredentialSecret:
+              type: string
+            displayName:
+              type: string
+            imported:
+              type: boolean
+            kmsKey:
+              nullable: true
+              type: string
+            kubernetesVersion:
+              nullable: true
+              type: string
+            loggingTypes:
+              items:
+                type: string
+              nullable: true
+              type: array
+            nodeGroups:
+              items:
+                properties:
+                  desiredSize:
+                    nullable: true
+                    type: integer
+                  diskSize:
+                    nullable: true
+                    type: integer
+                  ec2SshKey:
+                    nullable: true
+                    type: string
+                  gpu:
+                    nullable: true
+                    type: boolean
+                  instanceType:
+                    nullable: true
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    nullable: true
+                    type: object
+                  maxSize:
+                    nullable: true
+                    type: integer
+                  minSize:
+                    nullable: true
+                    type: integer
+                  nodegroupName:
+                    nullable: true
+                    type: string
+                  subnets:
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  tags:
+                    additionalProperties:
+                      type: string
+                    nullable: true
+                    type: object
+                  version:
+                    nullable: true
+                    type: string
+                required:
+                - nodegroupName
+                - instanceType
+                type: object
+              nullable: true
+              type: array
+            privateAccess:
+              nullable: true
+              type: boolean
+            publicAccess:
+              nullable: true
+              type: boolean
+            publicAccessSources:
+              items:
+                type: string
+              nullable: true
+              type: array
+            region:
+              type: string
+            secretsEncryption:
+              nullable: true
+              type: boolean
+            securityGroups:
+              items:
+                type: string
+              nullable: true
+              type: array
+            serviceRole:
+              nullable: true
+              type: string
+            subnets:
+              items:
+                type: string
+              nullable: true
+              type: array
+            tags:
+              additionalProperties:
+                type: string
+              nullable: true
+              type: object
+          type: object
+        status:
+          properties:
+            failureMessage:
+              type: string
+            networkFieldsSource:
+              type: string
+            phase:
+              type: string
+            securityGroups:
+              items:
+                type: string
+              nullable: true
+              type: array
+            subnets:
+              items:
+                type: string
+              nullable: true
+              type: array
+            virtualNetwork:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/rancher-eks-operator/1.0.600/templates/eksclusterconfig.yaml
+++ b/charts/rancher-eks-operator/1.0.600/templates/eksclusterconfig.yaml
@@ -20,8 +20,10 @@ spec:
         spec:
           properties:
             amazonCredentialSecret:
+              nullable: true
               type: string
             displayName:
+              nullable: true
               type: string
             imported:
               type: boolean
@@ -33,6 +35,7 @@ spec:
               type: string
             loggingTypes:
               items:
+                nullable: true
                 type: string
               nullable: true
               type: array
@@ -51,13 +54,30 @@ spec:
                   gpu:
                     nullable: true
                     type: boolean
+                  imageId:
+                    nullable: true
+                    type: string
                   instanceType:
                     nullable: true
                     type: string
                   labels:
                     additionalProperties:
+                      nullable: true
                       type: string
                     nullable: true
+                    type: object
+                  launchTemplate:
+                    nullable: true
+                    properties:
+                      id:
+                        nullable: true
+                        type: string
+                      name:
+                        nullable: true
+                        type: string
+                      version:
+                        nullable: true
+                        type: integer
                     type: object
                   maxSize:
                     nullable: true
@@ -68,22 +88,41 @@ spec:
                   nodegroupName:
                     nullable: true
                     type: string
+                  requestSpotInstances:
+                    nullable: true
+                    type: boolean
+                  resourceTags:
+                    additionalProperties:
+                      nullable: true
+                      type: string
+                    nullable: true
+                    type: object
+                  spotInstanceTypes:
+                    items:
+                      nullable: true
+                      type: string
+                    nullable: true
+                    type: array
                   subnets:
                     items:
+                      nullable: true
                       type: string
                     nullable: true
                     type: array
                   tags:
                     additionalProperties:
+                      nullable: true
                       type: string
                     nullable: true
                     type: object
+                  userData:
+                    nullable: true
+                    type: string
                   version:
                     nullable: true
                     type: string
                 required:
                 - nodegroupName
-                - instanceType
                 type: object
               nullable: true
               type: array
@@ -95,16 +134,19 @@ spec:
               type: boolean
             publicAccessSources:
               items:
+                nullable: true
                 type: string
               nullable: true
               type: array
             region:
+              nullable: true
               type: string
             secretsEncryption:
               nullable: true
               type: boolean
             securityGroups:
               items:
+                nullable: true
                 type: string
               nullable: true
               type: array
@@ -113,11 +155,13 @@ spec:
               type: string
             subnets:
               items:
+                nullable: true
                 type: string
               nullable: true
               type: array
             tags:
               additionalProperties:
+                nullable: true
                 type: string
               nullable: true
               type: object
@@ -125,22 +169,43 @@ spec:
         status:
           properties:
             failureMessage:
+              nullable: true
               type: string
+            managedLaunchTemplateID:
+              nullable: true
+              type: string
+            managedLaunchTemplateVersions:
+              additionalProperties:
+                nullable: true
+                type: string
+              nullable: true
+              type: object
             networkFieldsSource:
+              nullable: true
               type: string
             phase:
+              nullable: true
               type: string
             securityGroups:
               items:
+                nullable: true
                 type: string
               nullable: true
               type: array
             subnets:
               items:
+                nullable: true
+                type: string
+              nullable: true
+              type: array
+            templateVersionsToDelete:
+              items:
+                nullable: true
                 type: string
               nullable: true
               type: array
             virtualNetwork:
+              nullable: true
               type: string
           type: object
       type: object

--- a/charts/rancher-eks-operator/1.0.600/templates/serviceaccount.yaml
+++ b/charts/rancher-eks-operator/1.0.600/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: cattle-system
+  name: eks-operator

--- a/charts/rancher-eks-operator/1.0.600/values.yaml
+++ b/charts/rancher-eks-operator/1.0.600/values.yaml
@@ -1,0 +1,11 @@
+global:
+  systemDefaultRegistry: ""
+
+eksOperator:
+  image:
+    repository: rancher/eks-operator
+    tag: v1.0.5
+
+httpProxy: ""
+httpsProxy: ""
+noProxy: ""

--- a/charts/rancher-eks-operator/1.0.600/values.yaml
+++ b/charts/rancher-eks-operator/1.0.600/values.yaml
@@ -4,7 +4,7 @@ global:
 eksOperator:
   image:
     repository: rancher/eks-operator
-    tag: v1.0.5
+    tag: v1.0.6-rc1
 
 httpProxy: ""
 httpsProxy: ""


### PR DESCRIPTION
These changes include support for launch templates and spot instances for managed EKS clusters.

eks-operator PR:
https://github.com/rancher/eks-operator/pull/27

Issue:
https://github.com/rancher/rancher/issues/28803