### PR TITLE
Set rancher_min_version to 2.5.6 for eks-operator 1.0.6

### DIFF
--- a/charts/rancher-eks-operator/1.0.600/questions.yaml
+++ b/charts/rancher-eks-operator/1.0.600/questions.yaml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.5.0-alpha1
+rancher_min_version: 2.5.6-alpha1


### PR DESCRIPTION
Issue:
https://github.com/rancher/rancher/issues/31062