### PR TITLE
Update configmap-reloader for 2004/20H2 in logging

### DIFF
--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-linux/values.yaml
@@ -51,6 +51,6 @@ configmapReload:
   name: reloader
   image:
     repository: rancher/configmap-reload
-    tag: v0.3.0-rancher3
+    tag: v0.3.0-rancher4
     pullPolicy: IfNotPresent
   resources: {}

--- a/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/values.yaml
+++ b/charts/rancher-logging/0.2.3/charts/fluentd/charts/fluentd-windows/values.yaml
@@ -47,6 +47,6 @@ configmapReload:
   image:
     os: windows
     repository: rancher/configmap-reload
-    tag: v0.3.0-rancher3
+    tag: v0.3.0-rancher4
     pullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
Relevant issue: https://github.com/rancher/rancher/issues/30808

We are using the same chart version (`0.2.3`) since it has been unreleased.