### PR TITLE
Add required quotes for GKE CRD annotation

### DIFF
--- a/charts/rancher-gke-operator/1.0.100/templates/gkeclusterconfig.yaml
+++ b/charts/rancher-gke-operator/1.0.100/templates/gkeclusterconfig.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    helm.sh/resource-policy: keep
+    "helm.sh/resource-policy": keep
   name: gkeclusterconfigs.gke.cattle.io
 spec:
   group: gke.cattle.io


### PR DESCRIPTION
See the note in the helm documentation[1]. The CRD was getting
uninstalled when the workload was deleted, causing an issue with
redeploying it. Adding the quotes to the annotation should fix it and
make it consistent with other charts in this repo.

[1] https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource