### PR TITLE
Use rancher/mirrored-library-nginx 1.19.9-alpine

### DIFF
--- a/charts/rancher-monitoring/v0.2.2/values.yaml
+++ b/charts/rancher-monitoring/v0.2.2/values.yaml
@@ -257,8 +257,8 @@ grafana:
       repository: rancher/prometheus-auth
       tag: v0.2.1
     proxy:
-      repository: rancher/library-nginx
-      tag: 1.19.2-alpine
+      repository: rancher/mirrored-library-nginx
+      tag: 1.19.9-alpine
   nodeSelectors: []
   resources:
     inits:
@@ -317,7 +317,7 @@ prometheus:
       repository: rancher/prometheus-auth
       tag: v0.2.1
     proxy:
-      repository: rancher/library-nginx
+      repository: rancher/mirrored-library-nginx
       tag: 1.19.9-alpine
     thanos:
       repository: rancher/thanosio-thanos


### PR DESCRIPTION
The image rancher/library-nginx:1.19.9-alpine does not exist.
Replaced with rancher/mirrored-library-nginx:1.19.9-alpine.
Grafana nginx image was not updated previously, it has now
been updated to use the new repo and version 1.19.9-alpine.

**Issue:**
https://github.com/rancher/rancher/issues/32010
