### PR TITLE
Update charts missing rancher version min/max

### DIFF
--- a/charts/rancher-eks-operator/1.0.100/questions.yaml
+++ b/charts/rancher-eks-operator/1.0.100/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.5.0-alpha1
+rancher_max_version: 2.5.7

--- a/charts/rancher-eks-operator/1.0.101/questions.yaml
+++ b/charts/rancher-eks-operator/1.0.101/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.5.0-alpha1
+rancher_max_version: 2.5.7

--- a/charts/rancher-eks-operator/1.0.400/questions.yaml
+++ b/charts/rancher-eks-operator/1.0.400/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.5.0-alpha1
+rancher_max_version: 2.5.7

--- a/charts/rancher-eks-operator/1.0.500/questions.yaml
+++ b/charts/rancher-eks-operator/1.0.500/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.5.0-alpha1
+rancher_max_version: 2.5.7

--- a/charts/rancher-eks-operator/1.0.600/questions.yaml
+++ b/charts/rancher-eks-operator/1.0.600/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.5.6-alpha1
+rancher_max_version: 2.5.7

--- a/charts/rancher-eks-operator/1.0.700/questions.yaml
+++ b/charts/rancher-eks-operator/1.0.700/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.5.6-alpha1
+rancher_max_version: 2.5.7

--- a/charts/rancher-external-dns/v0.0.1/questions.yaml
+++ b/charts/rancher-external-dns/v0.0.1/questions.yaml
@@ -1,6 +1,2 @@
 rancher_min_version: 2.3.0-rc1
 rancher_max_version: 2.5.7
-categories:
-  - Logging
-
-questions:

--- a/charts/rancher-external-dns/v0.0.2/questions.yaml
+++ b/charts/rancher-external-dns/v0.0.2/questions.yaml
@@ -1,6 +1,2 @@
 rancher_min_version: 2.3.0-rc1
 rancher_max_version: 2.5.7
-categories:
-  - Logging
-
-questions:

--- a/charts/rancher-external-dns/v0.1.0/questions.yaml
+++ b/charts/rancher-external-dns/v0.1.0/questions.yaml
@@ -1,6 +1,2 @@
 rancher_min_version: 2.3.0-rc1
 rancher_max_version: 2.5.7
-categories:
-  - Logging
-
-questions:

--- a/charts/rancher-external-dns/v0.1.1/questions.yaml
+++ b/charts/rancher-external-dns/v0.1.1/questions.yaml
@@ -1,6 +1,2 @@
 rancher_min_version: 2.3.0-rc1
 rancher_max_version: 2.5.7
-categories:
-  - Logging
-
-questions:

--- a/charts/rancher-external-dns/v0.1.2/questions.yaml
+++ b/charts/rancher-external-dns/v0.1.2/questions.yaml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.3.0-rc1

--- a/charts/rancher-k3s-upgrader/0.1.0/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.1.0/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.4.0-rc1
+rancher_max_version: 2.5.7

--- a/charts/rancher-k3s-upgrader/0.2.0/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.2.0/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.4.0-rc1
+rancher_max_version: 2.5.7

--- a/charts/rancher-logging/0.1.1/questions.yml
+++ b/charts/rancher-logging/0.1.1/questions.yml
@@ -1,4 +1,6 @@
+rancher_min_version: 2.3.0-rc1
+rancher_max_version: 2.5.7
 categories:
-- Logging
+  - Logging
 
 questions:

--- a/charts/rancher-logging/0.1.2/questions.yml
+++ b/charts/rancher-logging/0.1.2/questions.yml
@@ -1,4 +1,6 @@
+rancher_min_version: 2.3.0-rc1
+rancher_max_version: 2.5.7
 categories:
-- Logging
+  - Logging
 
 questions:

--- a/charts/rancher-logging/0.1.3/questions.yml
+++ b/charts/rancher-logging/0.1.3/questions.yml
@@ -1,4 +1,6 @@
+rancher_min_version: 2.3.0-rc1
+rancher_max_version: 2.5.7
 categories:
-- Logging
+  - Logging
 
 questions:

--- a/charts/rancher-logging/0.1.4/questions.yml
+++ b/charts/rancher-logging/0.1.4/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.3.4-rc1
+rancher_max_version: 2.5.7

--- a/charts/rancher-logging/0.2.0/questions.yml
+++ b/charts/rancher-logging/0.2.0/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.3.4-rc1
+rancher_max_version: 2.5.7

--- a/charts/rancher-logging/0.2.1/questions.yml
+++ b/charts/rancher-logging/0.2.1/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.3.4-rc1
+rancher_max_version: 2.5.7

--- a/charts/rancher-logging/0.2.2/questions.yml
+++ b/charts/rancher-logging/0.2.2/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.3.4-rc1
+rancher_max_version: 2.5.7

--- a/charts/rancher-logging/0.2.3/questions.yml
+++ b/charts/rancher-logging/0.2.3/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.3.4-rc1
+rancher_max_version: 2.5.7

--- a/charts/rancher-monitoring/v0.0.1/questions.yml
+++ b/charts/rancher-monitoring/v0.0.1/questions.yml
@@ -1,1 +1,2 @@
+rancher_min_version: 2.1.0-rc1
 rancher_max_version: 2.2.99

--- a/charts/rancher-monitoring/v0.0.2/questions.yml
+++ b/charts/rancher-monitoring/v0.0.2/questions.yml
@@ -1,1 +1,2 @@
+rancher_min_version: 2.1.0-rc1
 rancher_max_version: 2.2.99

--- a/charts/rancher-monitoring/v0.0.3/questions.yml
+++ b/charts/rancher-monitoring/v0.0.3/questions.yml
@@ -1,1 +1,2 @@
+rancher_min_version: 2.1.0-rc1
 rancher_max_version: 2.2.99


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/31568

Updated charts missing a min/max to use min `rancher_min_version: 2.3.0-rc1` and `rancher_max_version: 2.5.7` (excluding latest since we don't want to set a max in those).