### PR TITLE
[2.6] Use Mirrored image for external dns chart

### DIFF
--- a/charts/rancher-external-dns/v0.0.1/questions.yml
+++ b/charts/rancher-external-dns/v0.0.1/questions.yml
@@ -1,0 +1,1 @@
+rancher_max_version: 2.5.8

--- a/charts/rancher-external-dns/v0.0.2/questions.yml
+++ b/charts/rancher-external-dns/v0.0.2/questions.yml
@@ -1,0 +1,1 @@
+rancher_max_version: 2.5.8

--- a/charts/rancher-external-dns/v0.1.0/questions.yml
+++ b/charts/rancher-external-dns/v0.1.0/questions.yml
@@ -1,0 +1,1 @@
+rancher_max_version: 2.5.8

--- a/charts/rancher-external-dns/v0.1.1/questions.yml
+++ b/charts/rancher-external-dns/v0.1.1/questions.yml
@@ -1,0 +1,1 @@
+rancher_max_version: 2.5.8

--- a/charts/rancher-external-dns/v0.1.2/questions.yml
+++ b/charts/rancher-external-dns/v0.1.2/questions.yml
@@ -1,0 +1,1 @@
+rancher_max_version: 2.5.8

--- a/charts/rancher-external-dns/v0.1.3/.helmignore
+++ b/charts/rancher-external-dns/v0.1.3/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/rancher-external-dns/v0.1.3/Chart.yaml
+++ b/charts/rancher-external-dns/v0.1.3/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: |
+  Configure external DNS servers (AWS Route53, Google CloudDNS and others)
+  for Kubernetes Ingresses and Services
+name: rancher-external-dns
+version: 0.1.2
+appVersion: 0.7.3
+home: https://github.com/kubernetes-sigs/external-dns
+sources:
+  - https://github.com/kubernetes-sigs/external-dns
+engine: gotpl
+maintainers:
+- name: rabadin
+  email: rabadin@cisco.com

--- a/charts/rancher-external-dns/v0.1.3/README.md
+++ b/charts/rancher-external-dns/v0.1.3/README.md
@@ -1,0 +1,133 @@
+# external-dns
+
+## Chart Details
+
+This chart will do the following:
+
+* Create a deployment of [external-dns] within your Kubernetes Cluster.
+
+Currently this uses official images from release notes at https://github.com/kubernetes-sigs/external-dns, if this is a concern follow the steps in the [external-dns] documentation to compile the binary and make a container. Where the chart pulls the image from is fully configurable.
+
+> **Note**: If you want to use Chart version >1.1.0 with external-dns image <0.5.9 and use aws credentials, make sure to set `aws.credentialsPath: "/root/.aws"`
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/external-dns
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the external-dns chart and their default values.
+
+
+| Parameter                          | Description                                                                                                                | Default                                            |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `annotationFilter`                 | Filter sources managed by external-dns via annotation using label selector semantics (default: all sources) (optional).    | `""`                                               |
+| `aws.accessKey`                    | set in `~/.aws/credentials` mounted through secret (optional).                                                             | `""`                                               |
+| `aws.secretKey`                    | set in `~/.aws/credentials` mounted through secret (optional).                                                             | `""`                                               |
+| `aws.credentialsPath`              | determine `mountPath` for `credentials` secret, defaults to `nobody` USER  home path `/.aws` (optional).                   | `"/.aws"`                                               |
+| `aws.region`                       | `AWS_DEFAULT_REGION` to set in the environment (optional).                                                                 | `us-east-1`                                        |
+| `aws.roleArn`                      | If assume role credentials are used then is the role_arn (arn:aws:iam::....). Leave empty if not used.                     | `""`                                               |
+| `aws.zoneType`                     | Filter for zones of this type (optional, options: public, private).                                                        | `""`                                               |
+| `aws.batchChangeSize`              | Batch size for Route53 changes.                                                                                            | `100`                                              |
+| `azure.secretName`                 | Set the secret created for the SP for azure, should contain an azure.json file                                             | `""`                                               |
+| `cloudflare.apiKey`                | `CF_API_KEY` to set in the environment (optional).                                                                         | `""`                                               |
+| `cloudflare.email`                 | `CF_API_EMAIL` to set in the environment (optional).                                                                       | `""`                                               |
+| `cloudflare.proxied`                 | enable the proxy feature of Cloudflare (DDOS protection, CDN...) (optional).                                                                       | `true`                                               |
+| `designate.customCA.enabled`       | A switch to enable a custom CA for the Designate provider (optional)                                                       | false                                              |
+| `designate.customCA.content`       | The content of the Designate provider's custom CA                                                                          | ""                                                 |
+| `designate.customCA.directory`     | Directory in which to mount the Designate provider's custom CA                                                             | "/config/designate"                                |
+| `designate.customCA.filename`      | Filename of Designate provider's custom CA                                                                                 | "designate-ca.pem"                                 |
+| `domainFilters`                    | Limit possible target zones by domain suffixes (optional).                                                                 | `[]`                                               |
+| `dryRun`                           | When enabled, prints DNS record changes rather than actually performing them (optional).                                   | `false`                                            |
+| `extraArgs`                        | Optional object of extra args, as `name`: `value` pairs. Where the name is the command line arg to external-dns.           | `{}`                                               |
+| `extraEnv`                         | Optional array of extra environment variables. Supply a `name` property and either `value` of `valueFrom` for each.        | `[]`                                               |
+| `google.project`                   | When using the Google provider, specify the Google project (required when provider=google).                                | `""`                                               |
+| `google.serviceAccountSecret`      | When using the Google provider, optionally specify the existing secret which contains credentials.json if necessary.                | `""`                                               |
+| `google.serviceAccountKey`      | When using the Google provider, optionally specify the service account key JSON file. Must be provided when no existing secret is used, in this case a new secret will be created holding this service account               |  `""`                                               |
+| `image.repository`                  | Container image name (Including repository name if not `hub.docker.com`).                                                  | `registry.opensource.zalan.do/teapot/external-dns` |
+| `image.pullPolicy`                 | Container pull policy.                                                                                                     | `IfNotPresent`                                     |
+| `image.tag`                        | Container image tag.                                                                                                       | `v0.5.9`                                           |
+| `image.pullSecrets`                | Array of pull secret names                                                                                                 | `[]`                                               |
+| `infoblox.gridHost`                | When using the Infoblox provider, specify the Infoblox Grid host.                                                          | `""`                                               |
+| `infoblox.wapiUsername`            | When using the Infoblox provider, specify the Infoblox WAPI username.                                                      | `""`                                               |
+| `infoblox.wapiPassword`            | When using the Infoblox provider, specify the Infoblox WAPI password.                                                      | `""`                                               |
+| `infoblox.domainFilter`            | When using the Infoblox provider, optionally specify the domain.                                                           | `""`                                               |
+| `infoblox.noSslVerify`             | When using the Infoblox provider, optionally disable SSL verification.                                                     | `false`                                            |
+| `infoblox.wapiPort`                | When using the Infoblox provider, optionally specify the Infoblox WAPI port.                                               | `""`                                               |
+| `infoblox.wapiVersion`             | When using the Infoblox provider, optionally specify the Infoblox WAPI version.                                            | `""`                                               |
+| `infoblox.wapiConnectionPoolSize`  | When using the Infoblox provider, optionally specify the Infoblox WAPI request connection pool size.                       | `""`                                               |
+| `infoblox.wapiHttpTimeout`         | When using the Infoblox provider, optionally specify the Infoblox WAPI request timeout in seconds.                         | `""`                                               |
+| `logLevel`                         | Verbosity of the logs (options: panic, debug, info, warn, error, fatal)                                                    | `info`                                             |
+| `nodeSelector`                     | Node labels for pod assignment                                                                                             | `{}`                                               |
+| `podAnnotations`                   | Additional annotations to apply to the pod.                                                                                | `{}`                                               |
+| `policy`                           | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only ).                        | `upsert-only`                                      |
+| `provider`                         | The DNS provider where the DNS records will be created (options: aws, google, azure, cloudflare, digitalocean, inmemory ). | `aws`                                              |
+| `publishInternalServices`          | Allow external-dns to publish DNS records for ClusterIP services (optional).                                               | `false`                                            |
+| `rbac.create`                      | If true, create & use RBAC resources                                                                                       | `false`                                            |
+| `rbac.serviceAccountName`          | Existing ServiceAccount to use (ignored if rbac.create=true)                                                               | `default`                                          |
+| `interval`                         | Interval update period to use (options: txt, noop)                                                                                | `txt`                                              |
+| `registry`                         | Registry method to use (options: txt, noop)                                                                                | `txt`                                              |
+| `resources`                        | CPU/Memory resource requests/limits.                                                                                       | `{}`                                               |
+| `securityContext`                  | Security options the pod should run with. [More info](https://kubernetes.io/docs/concepts/policy/security-context/)        | `{}`                                               |
+| `priorityClassName`                | priorityClassName                                                                                                          | `""`                                               |
+| `service.annotations`              | Annotations to add to service                                                                                              | `{}`                                               |
+| `service.clusterIP`                | IP address to assign to service                                                                                            | `""`                                               |
+| `service.externalIPs`              | Service external IP addresses                                                                                              | `[]`                                               |
+| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                       | `""`                                               |
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                            | `[]`                                               |
+| `service.servicePort`              | Service port to expose                                                                                                     | `7979`                                             |
+| `service.type`                     | Type of service to create                                                                                                  | `ClusterIP`                                        |
+| `sources`                          | List of resource types to monitor, possible values are fake, service or ingress.                                           | `[service, ingress]`                               |
+| `tolerations`                      | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                               | `[]`                                               |
+| `affinity`                         | List of affinities (requires Kubernetes >=1.6)                                                                             | `{}`                                               |
+| `txtOwnerId`                       | When using the TXT registry, a name that identifies this instance of ExternalDNS (optional)                                | `"default"`                                        |
+| `txtPrefix`                        | When using the TXT registry, a prefix for ownership records that avoids collision with CNAME entries (optional)            | `""`                                               |
+| `zoneIdFilters`                    | Limit possible target zones by zone id (optional)                                                                          | `[]`                                               |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/external-dns
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## IAM Permissions
+
+```json
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Effect": "Allow",
+     "Action": [
+       "route53:ChangeResourceRecordSets"
+     ],
+     "Resource": [
+       "arn:aws:route53:::hostedzone/*"
+     ]
+   },
+   {
+     "Effect": "Allow",
+     "Action": [
+       "route53:ListHostedZones",
+       "route53:ListResourceRecordSets"
+     ],
+     "Resource": [
+       "*"
+     ]
+   }
+ ]
+}
+```
+
+[external-dns]: https://github.com/kubernetes-incubator/external-dns
+[Zalando]: https://zalando.github.io/
+[getting-started]: https://github.com/kubernetes-incubator/external-dns/blob/master/README.md#getting-started

--- a/charts/rancher-external-dns/v0.1.3/questions.yml
+++ b/charts/rancher-external-dns/v0.1.3/questions.yml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.5.9-alpha1

--- a/charts/rancher-external-dns/v0.1.3/templates/NOTES.txt
+++ b/charts/rancher-external-dns/v0.1.3/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that external-dns has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "external-dns.name" . }},release={{ .Release.Name }}"

--- a/charts/rancher-external-dns/v0.1.3/templates/_helpers.tpl
+++ b/charts/rancher-external-dns/v0.1.3/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "external-dns.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "external-dns.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "external-dns.labels" }}
+app: {{ template "external-dns.name" . }}
+heritage: {{.Release.Service }}
+release: {{.Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}
+
+{{- define "external-dns.aws-credentials" }}
+[default]
+aws_access_key_id = {{ .Values.aws.accessKey }}
+aws_secret_access_key = {{ .Values.aws.secretKey }}
+{{ end }}
+
+
+{{- define "external-dns.aws-config" }}
+[profile default]
+{{- if .Values.aws.roleArn }}
+role_arn = {{ .Values.aws.roleArn }}
+{{- end }}
+region = {{ .Values.aws.region }}
+{{ end }}
+
+{{- define "external-dns.alibabacloud-config" }}
+accessKeyId: {{ .Values.alibabacloud.accessKey }}
+accessKeySecret: {{ .Values.alibabacloud.secretKey }}
+{{ end }}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "deployment_api_version" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+{{- "apps/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta2" -}}
+{{- "apps/v1beta2" -}}
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta1" -}}
+{{- "apps/v1beta1" -}}
+{{- else -}}
+{{- "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-external-dns/v0.1.3/templates/clusterrole.yaml
+++ b/charts/rancher-external-dns/v0.1.3/templates/clusterrole.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: ClusterRole
+metadata:
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "external-dns.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - pods
+      - nodes
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/charts/rancher-external-dns/v0.1.3/templates/clusterrolebinding.yaml
+++ b/charts/rancher-external-dns/v0.1.3/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: ClusterRoleBinding
+metadata:
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "external-dns.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "external-dns.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "external-dns.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/rancher-external-dns/v0.1.3/templates/configmap.yaml
+++ b/charts/rancher-external-dns/v0.1.3/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+data:
+  {{ .Values.designate.customCA.filename }}: |
+{{ .Values.designate.customCA.content | indent 4 }}
+{{- end }}

--- a/charts/rancher-external-dns/v0.1.3/templates/deployment.yaml
+++ b/charts/rancher-external-dns/v0.1.3/templates/deployment.yaml
@@ -1,0 +1,266 @@
+apiVersion: {{ template "deployment_api_version" . }}
+kind: Deployment
+metadata:
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "external-dns.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{ include "external-dns.labels" . | indent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    {{- if .Values.podAnnotations }} 
+{{ toYaml .Values.podAnnotations | indent 8}}
+    {{- end }}
+      labels: {{ include "external-dns.labels" . | indent 8 }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $sec := .Values.image.pullSecrets }}
+        - name: {{$sec | quote }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      containers:
+        - name: {{ template "external-dns.name" . }}
+          image: {{ template "system_default_registry" . }}{{ .Values.image.repository}}:{{ .Values.image.tag }}
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          args:
+          {{- if .Values.logLevel }}
+            - --log-level={{ .Values.logLevel }}
+          {{- end }}
+          {{- if .Values.publishInternalServices }}
+            - --publish-internal-services
+          {{- end }}
+          {{- range .Values.domainFilters }}
+            - --domain-filter={{ . }}
+          {{- end }}
+          {{- range .Values.zoneIdFilters }}
+            - --zone-id-filter={{ . }}
+          {{- end }}
+            - --policy={{ .Values.policy }}
+            - --provider={{ .Values.provider }}
+            - --registry={{ .Values.registry }}
+            - --interval={{ .Values.interval }}
+          {{- if .Values.txtOwnerId }}
+            - --txt-owner-id={{ .Values.txtOwnerId }}
+          {{- end }}
+          {{- if .Values.txtPrefix }}
+            - --txt-prefix={{ .Values.txtPrefix }}
+          {{- end }}
+          {{- if .Values.annotationFilter }}
+            - --annotation-filter={{ .Values.annotationFilter }}
+          {{- end }}
+          {{- range .Values.sources }}
+            - --source={{ . }}
+          {{- end }}
+          {{ if .Values.dryRun }}
+            - --dry-run
+          {{- end }}
+          {{- range $key, $value := .Values.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+          {{- if eq .Values.provider "cloudflare" }}
+            {{- if .Values.cloudflare.proxied }}
+            - --cloudflare-proxied
+            {{- end }}
+          {{- end }}
+          {{- if .Values.aws.zoneType }}
+            - --aws-zone-type={{ .Values.aws.zoneType }}
+          {{- end }}
+          {{- if .Values.google.project }}
+            - --google-project={{ .Values.google.project }}
+          {{- end }}
+          {{- if eq .Values.provider "aws" }}
+            - --aws-batch-change-size={{ .Values.aws.batchChangeSize }}
+          {{- end }}
+          {{- if eq .Values.provider "infoblox" }}
+            - --infoblox-grid-host={{ .Values.infoblox.gridHost }}
+            {{- if .Values.infoblox.domainFilter }}
+            - --domain-filter={{ .Values.infoblox.domainFilter }}
+            {{- end }}
+            {{- if .Values.infoblox.wapiPort }}
+            - --infoblox-wapi-port={{ .Values.infoblox.wapiPort }}
+            {{- end }}
+            {{- if .Values.infoblox.wapiVersion }}
+            - --infoblox-wapi-version={{ .Values.infoblox.wapiVersion }}
+            {{- end }}
+            {{- if .Values.infoblox.noSslVerify }}
+            - --no-infoblox-ssl-verify
+            {{- else }}
+            - --infoblox-ssl-verify
+            {{- end }}
+          {{- end }}
+          {{- if eq .Values.provider "alibabacloud" }}
+            - --alibaba-cloud-config-file=/etc/kubernetes/config.yaml
+          {{- end }}
+          {{- if .Values.alibabacloud.zoneType }}
+            - --alibaba-cloud-zone-type={{ .Values.alibabacloud.zoneType }}
+          {{- end }}
+          volumeMounts:
+          {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
+          - name: google-service-account
+            mountPath: /etc/secrets/service-account/
+          {{- end}}
+          {{- if eq .Values.provider "azure" }}
+          - name: azure-config-file
+            {{- if not .Values.azure.secretName }}
+            mountPath: /etc/kubernetes/azure.json
+            {{- else }}
+            mountPath: /etc/kubernetes/
+            {{- end }}
+            readOnly: true
+          {{- end }}
+          {{- if (and .Values.aws.secretKey .Values.aws.accessKey) }}
+          - name: aws-credentials
+            mountPath: {{ .Values.aws.credentialsPath }}
+            readOnly: true
+          {{- end }}
+          {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
+          - name: designate-custom-ca
+            mountPath: {{ .Values.designate.customCA.directory }}
+            readOnly: true
+          {{- end }}
+          {{- if eq .Values.provider "alibabacloud" }}
+          - name: alibaba-cloud-config-file
+            mountPath: /etc/kubernetes/
+            readOnly: true
+          - mountPath: /usr/share/zoneinfo
+            name: zoneinfo
+            readOnly: true
+          {{- end }}
+          env:
+        {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/secrets/service-account/credentials.json
+        {{- end }}
+        {{- if or (eq .Values.provider "aws") (eq .Values.provider "aws-sd") }}
+        {{- if .Values.aws.region }}
+          - name: AWS_DEFAULT_REGION
+            value: {{ .Values.aws.region }}
+        {{- end }}
+        {{- end }}
+        {{- if and .Values.cloudflare.apiKey .Values.cloudflare.email }}
+          - name: CF_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: cloudflare_api_key
+          - name: CF_API_EMAIL
+            value: "{{ .Values.cloudflare.email }}"
+        {{- end }}
+        {{- if .Values.infoblox.wapiConnectionPoolSize }}
+          - name: EXTERNAL_DNS_INFOBLOX_HTTP_POOL_CONNECTIONS
+            value: "{{ .Values.infoblox.wapiConnectionPoolSize }}"
+        {{- end }}
+        {{- if .Values.infoblox.wapiHttpTimeout }}
+          - name: EXTERNAL_DNS_INFOBLOX_HTTP_REQUEST_TIMEOUT
+            value: "{{ .Values.infoblox.wapiHttpTimeout }}"
+        {{- end }}
+        {{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
+          - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: infoblox_wapi_username
+          - name: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: infoblox_wapi_password
+        {{- end }}
+        {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
+          - name: OPENSTACK_CA_FILE
+            value: {{ .Values.designate.customCA.directory }}/{{ .Values.designate.customCA.filename }}
+        {{- end }}
+        {{- $root := . -}}
+        {{- range .Values.extraEnv }}
+          - name: {{ .name }}
+            valueFrom:
+          {{- if .valueFrom }}
+{{ toYaml .valueFrom | indent 14 }}
+          {{- else }}
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" $root }}
+                key: {{ .name }}
+          {{- end }}
+        {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 7979
+          ports:
+            - containerPort: 7979
+        {{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+        {{- end }}
+        {{- if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        {{- end }}
+      volumes:
+      {{- if .Values.google.serviceAccountSecret }}
+      - name: google-service-account
+        secret:
+          secretName: {{ .Values.google.serviceAccountSecret | quote }}
+      {{- else if .Values.google.serviceAccountKey }}
+      - name: google-service-account
+        secret:
+          secretName: {{ template "external-dns.fullname" . }}
+      {{- end}}
+      {{- if eq .Values.provider "azure" }}
+      - name: azure-config-file
+        {{- if (not .Values.azure.secretName)}}
+        hostPath:
+          path: /etc/kubernetes/azure.json
+          type: File
+        {{- else}}
+        secret:
+          secretName: {{.Values.azure.secretName}}
+        {{- end}}
+      {{- end }}
+      {{- if (and .Values.aws.secretKey .Values.aws.accessKey) }}
+      - name: aws-credentials
+        secret:
+          secretName: {{ template "external-dns.fullname" . }}
+      {{- end }}
+      {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
+      - name: designate-custom-ca
+        configMap:
+          name: {{ template "external-dns.fullname" . }}
+          items:
+          - key: {{ .Values.designate.customCA.filename }}
+            path: {{ .Values.designate.customCA.filename }}
+      {{- end }}
+      {{- if eq .Values.provider "alibabacloud" }}
+      - name: alibaba-cloud-config-file
+        secret:
+          secretName: {{ template "external-dns.fullname" . }}
+      - name: zoneinfo
+        hostPath:
+          path: /usr/share/zoneinfo
+      {{- end }}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+    {{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "external-dns.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}

--- a/charts/rancher-external-dns/v0.1.3/templates/secret.yaml
+++ b/charts/rancher-external-dns/v0.1.3/templates/secret.yaml
@@ -1,0 +1,33 @@
+{{- if or (and .Values.aws.secretKey .Values.aws.accessKey) .Values.cloudflare.apiKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.extraEnv .Values.google.serviceAccountKey (and .Values.alibabacloud.secretKey .Values.alibabacloud.accessKey) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "external-dns.fullname" . }}
+type: Opaque
+data:
+{{- if eq .Values.provider "aws" }}
+  credentials: {{ include "external-dns.aws-credentials" . | b64enc | quote }}
+  config: {{ include "external-dns.aws-config" . | b64enc | quote }}
+{{- end}}
+{{- if and (eq .Values.provider "google") .Values.google.serviceAccountKey }}
+  credentials.json: {{ .Values.google.serviceAccountKey | b64enc | quote }}
+{{- end}}
+{{- if .Values.cloudflare.apiKey }}
+  cloudflare_api_key: {{ .Values.cloudflare.apiKey | b64enc | quote }}
+{{- end }}
+{{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
+  infoblox_wapi_username: {{ .Values.infoblox.wapiUsername | b64enc | quote }}
+  infoblox_wapi_password: {{ .Values.infoblox.wapiPassword | b64enc | quote }}
+{{- end }}
+{{- if eq .Values.provider "alibabacloud" }}
+  config.yaml: {{ include "external-dns.alibabacloud-config" . | b64enc | quote }}
+{{- end}}
+
+{{- range .Values.extraEnv }}
+  {{- if .value }}
+  {{ .name }}: {{ .value | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-external-dns/v0.1.3/templates/service.yaml
+++ b/charts/rancher-external-dns/v0.1.3/templates/service.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "external-dns.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "external-dns.fullname" . }}
+spec:
+{{- if .Values.service.clusterIP }}
+  clusterIP: "{{ .Values.service.clusterIP }}"
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - port: {{ .Values.service.servicePort }}
+      protocol: TCP
+      targetPort: 7979
+      name: http
+  selector:
+    app: {{ template "external-dns.name" . }}
+    release: {{ .Release.Name }}
+  type: "{{ .Values.service.type }}"

--- a/charts/rancher-external-dns/v0.1.3/templates/serviceaccount.yaml
+++ b/charts/rancher-external-dns/v0.1.3/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "external-dns.fullname" . }}
+{{- end }}

--- a/charts/rancher-external-dns/v0.1.3/values.yaml
+++ b/charts/rancher-external-dns/v0.1.3/values.yaml
@@ -1,0 +1,179 @@
+## Details about the image to be pulled.
+image:
+  repository: rancher/kubernetes-external-dns
+  tag: v0.7.3
+  pullSecrets: []
+  pullPolicy: IfNotPresent
+
+## This controls which types of resource external-dns should 'watch' for new
+## DNS entries.
+sources:
+  - service
+  - ingress
+
+# Allow external-dns to publish DNS records for ClusterIP services (optional)
+publishInternalServices: false
+
+## The DNS provider where the DNS records will be created (options: aws, google, inmemory, azure, alibabacloud )
+provider: aws
+
+# Configurations for Alibabacloud provider
+alibabacloud:
+  accessKey: ""
+  secretKey: ""
+  # Filter for zones of this type (optional, options: public, private or no value for both)
+  zoneType: ""
+
+# AWS Access keys to inject as environment variables
+aws:
+  secretKey: ""
+  accessKey: ""
+  # pre external-dns 0.5.9 home dir should be `/root/.aws`
+  credentialsPath: "/.aws"
+  roleArn: ""
+  region: "us-east-1"
+  # Filter for zones of this type (optional, options: public, private)
+  zoneType: ""
+  # Batch size for Route53 changes
+  batchChangeSize: 100
+
+azure:
+# If you don't specify a secret to load azure.json from, you will get the host's /etc/kubernetes/azure.json
+  secretName: ""
+
+# Cloudflare keys to inject as environment variables
+cloudflare:
+  apiKey: ""
+  email: ""
+  proxied: true
+
+# Configuration for OpenStack Designate provider
+designate:
+  # A custom CA (optional)
+  customCA:
+    # Turn custom CA on or off
+    enabled: false
+    # The content of the custom CA file
+    content: ""
+    # Location to mount custom CA
+    directory: "/config/designate"
+    # Filename of the custom CA
+    filename: "designate-ca.pem"
+
+# When using the Google provider, specify the Google project (required when provider=google)
+google:
+  project: ""
+  serviceAccountSecret: ""
+  serviceAccountKey: ""
+
+# Infoblox keys to inject
+infoblox:
+  # Required keys:
+  wapiUsername: ""
+  wapiPassword: ""
+  gridHost: ""
+  # Optional keys:
+  domainFilter: ""
+  noSslVerify: false
+  wapiPort: ""
+  wapiVersion: ""
+  wapiConnectionPoolSize: ""
+  wapiHttpTimeout: ""
+
+## Limit possible target zones by domain suffixes (optional)
+domainFilters: []
+## Limit possible target zones by zone id (optional)
+zoneIdFilters: []
+# Filter sources managed by external-dns via annotation using label selector semantics (default: all sources)
+annotationFilter: ""
+## Adjust the interval for DNS updates
+interval: "1m"
+
+# Registry to use for ownership (txt or noop)
+registry: "txt"
+
+# When using the TXT registry, a name that identifies this instance of ExternalDNS
+txtOwnerId: ""
+
+# When enabled, prints DNS record changes rather than actually performing them
+dryRun: false
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## List of node taints to tolerate (requires Kubernetes >= 1.6)
+tolerations: []
+
+## Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only )
+policy: upsert-only
+
+## Annotations to be added to pods
+##
+podAnnotations: {}
+
+podLabels: {}
+
+# Verbosity of the logs (options: panic, debug, info, warn, error, fatal)
+logLevel: info
+
+extraArgs: {}
+
+# Extra environment variables which will be saved in a release-specific secret
+# or retrieved via valueFrom.
+# extraEnv:
+# - name: SECRET_TO_SAVE
+#   value: secret_value
+# - name: AWS_ACCESS_KEY_ID
+#   valueFrom:
+#     secretKeyRef:
+#       name: existing-secret
+#       key: access-key-id
+extraEnv: []
+
+## CPU and Memory limit and request for external-dns
+resources:
+  limits:
+    memory: 100Mi
+    cpu: 200m
+  requests:
+    memory: 50Mi
+    cpu: 100m
+
+rbac:
+  ## If true, create & use RBAC resources
+  ##
+  create: false
+  # Beginning with Kubernetes 1.8, the api is stable and v1 can be used.
+  apiVersion: v1beta1
+
+  ## Ignored if rbac.create is true
+  ##
+  serviceAccountName: default
+
+securityContext: {}
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 65534 # 65534 is nobody - revise aws.credentialsPath when changing uid
+  # capabilities:
+  #   drop: ["ALL"]
+
+service:
+  annotations: {}
+  clusterIP: ""
+
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  servicePort: 7979
+  type: ClusterIP
+
+priorityClassName: ""
+
+global:
+  systemDefaultRegistry: ""

--- a/charts/rancher-external-dns/v0.1.3/values.yaml
+++ b/charts/rancher-external-dns/v0.1.3/values.yaml
@@ -1,6 +1,6 @@
 ## Details about the image to be pulled.
 image:
-  repository: rancher/kubernetes-external-dns
+  repository: rancher/mirrored-kubernetes-external-dns
   tag: v0.7.3
   pullSecrets: []
   pullPolicy: IfNotPresent


### PR DESCRIPTION
This PR updates the image to the mirrored rancher/kubernetes-external-dns image for dev-v2.6.

https://github.com/rancher/rancher/issues/31873
https://github.com/rancher/rancher/issues/31598