### PR TITLE
Bump Alertmanager to v0.22.0

### DIFF
--- a/charts/rancher-monitoring/v0.2.3/values.yaml
+++ b/charts/rancher-monitoring/v0.2.3/values.yaml
@@ -207,8 +207,8 @@ alertmanager:
   enabled: false
   apiGroup: "monitoring.coreos.com"
   image:
-    repository: rancher/mirrored-prom-alertmanager
-    tag: v0.21.0
+    repository: rancher/mirrored-prometheus-alertmanager
+    tag: v0.22.0
   nodeSelectors: []
   resources:
     core:


### PR DESCRIPTION
https://github.com/prometheus/common/commit/9c5aa1eb995200ed442a9ca4d8b9694922d9cf93 introduced "support for more user-friendly duration input" and changed the output of the `String()` function for `Duration`. This internally converted the representation of something like `525600s` to `6d2h`.

The issue with this approach is that versions of Alertmanager <v0.22.0 (before common was bumped in https://github.com/prometheus/alertmanager/commit/470634d49fc629727d91cbb271d7c6e9bc282b06) still use the older version of `Duration` that did not support parsing input like `6d2h`, leading to error statements like the following when Rancher tried to modify the Alertmanager Secret based on the new formatting:

```
level=error ts=2021-03-04T20:24:45.688Z caller=coordinator.go:124 component=configuration msg="Loading configuration file failed" file=/etc/alertmanager/config/alertmanager.yaml err="not a valid duration string: \"6d2h\""
```

Therefore, this fix for this is to bump Alertmanager to v0.22.0. We do not need to support <v0.22.0 since Alerting V2 does not use Rancher controllers and Alerting V1 is set up to automatically upgrade on a Rancher upgrade.

Related Issue: https://github.com/rancher/rancher/issues/31522