### PR TITLE
Add additional trusted CAs to deployment

### DIFF
--- a/charts/rancher-gke-operator/1.1.100/templates/deployment.yaml
+++ b/charts/rancher-gke-operator/1.1.100/templates/deployment.yaml
@@ -25,3 +25,15 @@ spec:
           value: {{ .Values.httpsProxy }}
         - name: NO_PROXY
           value: {{ .Values.noProxy }}
+{{- if .Values.additionalTrustedCAs }}
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/ca-additional.pem
+          name: tls-ca-additional-volume
+          subPath: ca-additional.pem
+          readOnly: true
+      volumes:
+      - name: tls-ca-additional-volume
+        secret:
+          defaultMode: 0400
+          secretName: tls-ca-additional
+{{- end }}

--- a/charts/rancher-gke-operator/1.1.100/values.yaml
+++ b/charts/rancher-gke-operator/1.1.100/values.yaml
@@ -9,3 +9,4 @@ gkeOperator:
 httpProxy: ""
 httpsProxy: ""
 noProxy: ""
+additionalTrustedCAs: false


### PR DESCRIPTION
When Rancher is installed on a cluster behind a proxy, gke-operator
needs to trust the certificate from the proxy. Therefore, it is passed
to the deployment as a secret that is setup by the user as per the
documentation.

Issue:
https://github.com/rancher/rancher/issues/31846