### PR TITLE
Add additional trusted CAs if needed

### DIFF
--- a/charts/rancher-aks-operator/1.0.100/templates/deployment.yaml
+++ b/charts/rancher-aks-operator/1.0.100/templates/deployment.yaml
@@ -25,3 +25,15 @@ spec:
           value: {{ .Values.httpsProxy }}
         - name: NO_PROXY
           value: {{ .Values.noProxy }}
+{{- if .Values.additionalTrustedCAs }}
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/ca-additional.pem
+          name: tls-ca-additional-volume
+          subPath: ca-additional.pem
+          readOnly: true
+      volumes:
+      - name: tls-ca-additional-volume
+        secret:
+          defaultMode: 0400
+          secretName: tls-ca-additional
+{{- end }}

--- a/charts/rancher-aks-operator/1.0.100/values.yaml
+++ b/charts/rancher-aks-operator/1.0.100/values.yaml
@@ -9,3 +9,4 @@ aksOperator:
 httpProxy: ""
 httpsProxy: ""
 noProxy: ""
+additionalTrustedCAs: false


### PR DESCRIPTION
When Rancher is installed on a cluster behind a proxy, the operator
needs to trust the certificate from the proxy. This is done via the
deployment and a secret the user sets up as per the documentation.

Issue:
https://github.com/rancher/rancher/issues/31846