### PR TITLE
[release-v2.5] fix the min_rancher_version on monitoring and gke-operator

### DIFF
--- a/charts/rancher-gke-operator/1.0.100/questions.yaml
+++ b/charts/rancher-gke-operator/1.0.100/questions.yaml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.5.8-alpha1
+rancher_min_version: 2.5.8-patch1

--- a/charts/rancher-monitoring/v0.2.2/questions.yml
+++ b/charts/rancher-monitoring/v0.2.2/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.5.8-rc1
+rancher_min_version: 2.5.8-patch1


### PR DESCRIPTION
**This PR goes to the release-v2.5 branch** 

This is required is due to the custom ordering of semver used by the Rancher dependency in https://github.com/mcuadros/go-version/blob/master/compare.go#L13

This fix also goes to the dev-v2.5 branch: https://github.com/rancher/system-charts/pull/476