### PR TITLE
Forwardports gke-operator v1.0.200

### DIFF
--- a/charts/rancher-gke-operator/1.0.200/Chart.yaml
+++ b/charts/rancher-gke-operator/1.0.200/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+name: rancher-gke-operator
+description: A Helm chart for provisioning GKE clusters
+home: https://github.com/rancher/gke-operator
+sources:
+  - "https://github.com/rancher/gke-operator"
+version: 1.0.200
+appVersion: v1.0.2-rc1

--- a/charts/rancher-gke-operator/1.0.200/questions.yaml
+++ b/charts/rancher-gke-operator/1.0.200/questions.yaml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.5.8-patch1

--- a/charts/rancher-gke-operator/1.0.200/templates/NOTES.txt
+++ b/charts/rancher-gke-operator/1.0.200/templates/NOTES.txt
@@ -1,0 +1,4 @@
+You have deployed the Rancher GKE operator
+Version: {{ .Chart.AppVersion }}
+Description: This operator provisions GKE clusters
+from GKEClusterConfig CRs.

--- a/charts/rancher-gke-operator/1.0.200/templates/_helpers.tpl
+++ b/charts/rancher-gke-operator/1.0.200/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-gke-operator/1.0.200/templates/clusterrole.yaml
+++ b/charts/rancher-gke-operator/1.0.200/templates/clusterrole.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gke-operator
+  namespace: cattle-system
+rules:
+  - apiGroups: ['']
+    resources: ['secrets']
+    verbs: ['get', 'list', 'create', 'watch']
+  - apiGroups: ['gke.cattle.io']
+    resources: ['gkeclusterconfigs']
+    verbs: ['get', 'list', 'update', 'watch']
+  - apiGroups: ['gke.cattle.io']
+    resources: ['gkeclusterconfigs/status']
+    verbs: ['update']

--- a/charts/rancher-gke-operator/1.0.200/templates/clusterrolebinding.yaml
+++ b/charts/rancher-gke-operator/1.0.200/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  gke-operator
+  namespace: cattle-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gke-operator
+subjects:
+- kind: ServiceAccount
+  name: gke-operator
+  namespace: cattle-system

--- a/charts/rancher-gke-operator/1.0.200/templates/deployment.yaml
+++ b/charts/rancher-gke-operator/1.0.200/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gke-config-operator
+  namespace: cattle-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ke.cattle.io/operator: gke
+  template:
+    metadata:
+      labels:
+        ke.cattle.io/operator: gke
+    spec:
+      serviceAccountName: gke-operator
+      containers:
+      - name: gke-operator
+        image: {{ template "system_default_registry" . }}{{ .Values.gkeOperator.image.repository }}:{{ .Values.gkeOperator.image.tag }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: HTTP_PROXY
+          value: {{ .Values.httpProxy }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.httpsProxy }}
+        - name: NO_PROXY
+          value: {{ .Values.noProxy }}
+{{- if .Values.additionalTrustedCAs }}
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/ca-additional.pem
+          name: tls-ca-additional-volume
+          subPath: ca-additional.pem
+          readOnly: true
+      volumes:
+      - name: tls-ca-additional-volume
+        secret:
+          defaultMode: 0400
+          secretName: tls-ca-additional
+{{- end }}

--- a/charts/rancher-gke-operator/1.0.200/templates/gkeclusterconfig.yaml
+++ b/charts/rancher-gke-operator/1.0.200/templates/gkeclusterconfig.yaml
@@ -1,0 +1,243 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  name: gkeclusterconfigs.gke.cattle.io
+spec:
+  group: gke.cattle.io
+  names:
+    kind: GKEClusterConfig
+    plural: gkeclusterconfigs
+    shortNames:
+    - gkecc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            clusterAddons:
+              nullable: true
+              properties:
+                horizontalPodAutoscaling:
+                  type: boolean
+                httpLoadBalancing:
+                  type: boolean
+                networkPolicyConfig:
+                  type: boolean
+              type: object
+            clusterIpv4Cidr:
+              nullable: true
+              type: string
+            clusterName:
+              nullable: true
+              type: string
+            description:
+              nullable: true
+              type: string
+            enableKubernetesAlpha:
+              nullable: true
+              type: boolean
+            googleCredentialSecret:
+              nullable: true
+              type: string
+            imported:
+              type: boolean
+            ipAllocationPolicy:
+              nullable: true
+              properties:
+                clusterIpv4CidrBlock:
+                  nullable: true
+                  type: string
+                clusterSecondaryRangeName:
+                  nullable: true
+                  type: string
+                createSubnetwork:
+                  type: boolean
+                nodeIpv4CidrBlock:
+                  nullable: true
+                  type: string
+                servicesIpv4CidrBlock:
+                  nullable: true
+                  type: string
+                servicesSecondaryRangeName:
+                  nullable: true
+                  type: string
+                subnetworkName:
+                  nullable: true
+                  type: string
+                useIpAliases:
+                  type: boolean
+              type: object
+            kubernetesVersion:
+              nullable: true
+              type: string
+            labels:
+              additionalProperties:
+                nullable: true
+                type: string
+              nullable: true
+              type: object
+            locations:
+              items:
+                nullable: true
+                type: string
+              nullable: true
+              type: array
+            loggingService:
+              nullable: true
+              type: string
+            maintenanceWindow:
+              nullable: true
+              type: string
+            masterAuthorizedNetworks:
+              nullable: true
+              properties:
+                cidrBlocks:
+                  items:
+                    properties:
+                      cidrBlock:
+                        nullable: true
+                        type: string
+                      displayName:
+                        nullable: true
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                enabled:
+                  type: boolean
+              type: object
+            monitoringService:
+              nullable: true
+              type: string
+            network:
+              nullable: true
+              type: string
+            networkPolicyEnabled:
+              nullable: true
+              type: boolean
+            nodePools:
+              items:
+                properties:
+                  autoscaling:
+                    nullable: true
+                    properties:
+                      enabled:
+                        type: boolean
+                      maxNodeCount:
+                        type: integer
+                      minNodeCount:
+                        type: integer
+                    type: object
+                  config:
+                    nullable: true
+                    properties:
+                      diskSizeGb:
+                        type: integer
+                      diskType:
+                        nullable: true
+                        type: string
+                      imageType:
+                        nullable: true
+                        type: string
+                      labels:
+                        additionalProperties:
+                          nullable: true
+                          type: string
+                        nullable: true
+                        type: object
+                      localSsdCount:
+                        type: integer
+                      machineType:
+                        nullable: true
+                        type: string
+                      oauthScopes:
+                        items:
+                          nullable: true
+                          type: string
+                        nullable: true
+                        type: array
+                      preemptible:
+                        type: boolean
+                      taints:
+                        items:
+                          properties:
+                            effect:
+                              nullable: true
+                              type: string
+                            key:
+                              nullable: true
+                              type: string
+                            value:
+                              nullable: true
+                              type: string
+                          type: object
+                        nullable: true
+                        type: array
+                    type: object
+                  initialNodeCount:
+                    nullable: true
+                    type: integer
+                  management:
+                    nullable: true
+                    properties:
+                      autoRepair:
+                        type: boolean
+                      autoUpgrade:
+                        type: boolean
+                    type: object
+                  maxPodsConstraint:
+                    nullable: true
+                    type: integer
+                  name:
+                    nullable: true
+                    type: string
+                  version:
+                    nullable: true
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            privateClusterConfig:
+              nullable: true
+              properties:
+                enablePrivateEndpoint:
+                  type: boolean
+                enablePrivateNodes:
+                  type: boolean
+                masterIpv4CidrBlock:
+                  nullable: true
+                  type: string
+              type: object
+            projectID:
+              nullable: true
+              type: string
+            region:
+              nullable: true
+              type: string
+            subnetwork:
+              nullable: true
+              type: string
+            zone:
+              nullable: true
+              type: string
+          type: object
+        status:
+          properties:
+            failureMessage:
+              nullable: true
+              type: string
+            phase:
+              nullable: true
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/rancher-gke-operator/1.0.200/templates/serviceaccount.yaml
+++ b/charts/rancher-gke-operator/1.0.200/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: cattle-system
+  name: gke-operator

--- a/charts/rancher-gke-operator/1.0.200/values.yaml
+++ b/charts/rancher-gke-operator/1.0.200/values.yaml
@@ -1,0 +1,12 @@
+global:
+  systemDefaultRegistry: ""
+
+gkeOperator:
+  image:
+    repository: rancher/gke-operator
+    tag: v1.0.2-rc1
+
+httpProxy: ""
+httpsProxy: ""
+noProxy: ""
+additionalTrustedCAs: false


### PR DESCRIPTION
The new versioning changes require that versions in dev-v2.5 also exist
in dev-v2.6. This change copies the files from dev-v2.5.

2.5 PR:
https://github.com/rancher/system-charts/pull/472

Issue:
https://github.com/rancher/rancher/issues/32903