### PR TITLE
More k3s-upgrader changes 

### DIFF
--- a/charts/rancher-k3s-upgrader/0.3.0/templates/clusterrolebinding.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.0/templates/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name:  system-upgrade
+  name:  system-upgrade-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: system-upgrade
-  namespace: cattle-system
+  - kind: ServiceAccount
+    name: system-upgrade-controller
+    namespace: cattle-system

--- a/charts/rancher-k3s-upgrader/0.3.0/templates/configmap.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.0/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: default-controller-env
+  name: system-upgrade-controller-config
   namespace: cattle-system
 data:
   SYSTEM_UPGRADE_CONTROLLER_DEBUG: {{ .Values.systemUpgradeControllerDebug | default "false" | quote }}

--- a/charts/rancher-k3s-upgrader/0.3.0/templates/deployment.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.0/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
                   values:
                     - "true"
             weight: 100
+      tolerations:
+        operator: "Exists"
       serviceAccountName: system-upgrade
       containers:
         - name: system-upgrade-controller

--- a/charts/rancher-k3s-upgrader/0.3.0/templates/deployment.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.0/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
-                name: default-controller-env
+                name: system-upgrade-controller-config
           env:
             - name: SYSTEM_UPGRADE_CONTROLLER_NAME
               valueFrom:

--- a/charts/rancher-k3s-upgrader/0.3.0/templates/serviceaccount.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.0/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: system-upgrade
+  name: system-upgrade-controller
   namespace: cattle-system


### PR DESCRIPTION
- We're updating names for configmap, clusterrolebinding and serviceaccount to keep it consistent with system-upgrade-controller. 
- k3s-upgrader must deploy on control-plane nodes without any user intervention, adding tolerate everything so it tolerates taints added by rancher+user. 