### PR TITLE
add rancher min/max versions for charts

### DIFF
--- a/charts/rancher-cis-benchmark/0.1.2/questions.yaml
+++ b/charts/rancher-cis-benchmark/0.1.2/questions.yaml
@@ -1,2 +1,2 @@
 rancher_min_version: 2.4.6-rc1
-rancher_max_version: 2.5.8
+rancher_max_version: 2.5.99

--- a/charts/rancher-external-dns/v0.0.1/questions.yml
+++ b/charts/rancher-external-dns/v0.0.1/questions.yml
@@ -1,1 +1,1 @@
-rancher_max_version: 2.5.8
+rancher_max_version: 2.5.99

--- a/charts/rancher-external-dns/v0.0.2/questions.yml
+++ b/charts/rancher-external-dns/v0.0.2/questions.yml
@@ -1,1 +1,1 @@
-rancher_max_version: 2.5.8
+rancher_max_version: 2.5.99

--- a/charts/rancher-external-dns/v0.1.0/questions.yml
+++ b/charts/rancher-external-dns/v0.1.0/questions.yml
@@ -1,1 +1,1 @@
-rancher_max_version: 2.5.8
+rancher_max_version: 2.5.99

--- a/charts/rancher-external-dns/v0.1.1/questions.yml
+++ b/charts/rancher-external-dns/v0.1.1/questions.yml
@@ -1,1 +1,1 @@
-rancher_max_version: 2.5.8
+rancher_max_version: 2.5.99

--- a/charts/rancher-external-dns/v0.1.2/questions.yml
+++ b/charts/rancher-external-dns/v0.1.2/questions.yml
@@ -1,1 +1,1 @@
-rancher_max_version: 2.5.8
+rancher_max_version: 2.5.99

--- a/charts/rancher-external-dns/v0.2.0/questions.yml
+++ b/charts/rancher-external-dns/v0.2.0/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.5.9-alpha1
+rancher_min_version: 2.6.0-alpha1

--- a/charts/rancher-istio/1.5.920/questions.yaml
+++ b/charts/rancher-istio/1.5.920/questions.yaml
@@ -1,3 +1,3 @@
 labels:
   rancher.istio.v1.5.920: 1.5.9
-rancher_min_version: 2.6.0-rc1
+rancher_min_version: 2.6.0-alpha1

--- a/charts/rancher-k3s-upgrader/0.2.1/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.2.1/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.4.0-rc1
+rancher_max_version: 2.5.99

--- a/charts/rancher-k3s-upgrader/0.3.0/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.3.0/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.4.0-rc1
+rancher_min_version: 2.6.0-alpha1

--- a/charts/rancher-monitoring/v0.2.2/questions.yml
+++ b/charts/rancher-monitoring/v0.2.2/questions.yml
@@ -1,2 +1,2 @@
 rancher_min_version: 2.5.8-rc1
-rancher_max_version: 2.5.8
+rancher_max_version: 2.5.99

--- a/charts/rancher-monitoring/v0.3.0/questions.yml
+++ b/charts/rancher-monitoring/v0.3.0/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.5.9-rc1
+rancher_min_version: 2.6.0-alpha1


### PR DESCRIPTION
Addressing comments from https://github.com/rancher/system-charts/pull/517. 

The only chart I haven't updated is gatekeeper, because the max version was intentionally set to 2.4.99 since it moved to charts https://github.com/rancher/system-charts/commit/70e046f63634b3ed93260b37148b1b23c645e924. 