### PR TITLE
Bump eks-operator to 1.0.10-rc2

### DIFF
--- a/charts/rancher-eks-operator/1.0.1000/Chart.yaml
+++ b/charts/rancher-eks-operator/1.0.1000/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/rancher/eks-operator
 sources:
   - "https://github.com/rancher/eks-operator"
 version: 1.0.1000
-appVersion: v1.0.10-rc1
+appVersion: v1.0.10-rc2

--- a/charts/rancher-eks-operator/1.0.1000/templates/deployment.yaml
+++ b/charts/rancher-eks-operator/1.0.1000/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
         ke.cattle.io/operator: eks
     spec:
       serviceAccountName: eks-operator
+      securityContext:
+        fsGroup: 1007
+        runAsUser: 1007
       containers:
       - name: eks-operator
         image: {{ template "system_default_registry" . }}{{ .Values.eksOperator.image.repository }}:{{ .Values.eksOperator.image.tag }}
@@ -28,6 +31,12 @@ spec:
 {{- if .Values.additionalTrustedCAs }}
         volumeMounts:
         - mountPath: /etc/ssl/certs/ca-additional.pem
+          name: tls-ca-additional-volume
+          subPath: ca-additional.pem
+          readOnly: true
+         # This directory is root-owned so c_rehash doesn't work here,
+         # but the cert is here in case update-ca-certificates is called in the future or by the OS.
+        - mountPath: /etc/pki/trust/anchors/ca-additional.pem
           name: tls-ca-additional-volume
           subPath: ca-additional.pem
           readOnly: true

--- a/charts/rancher-eks-operator/1.0.1000/values.yaml
+++ b/charts/rancher-eks-operator/1.0.1000/values.yaml
@@ -4,7 +4,7 @@ global:
 eksOperator:
   image:
     repository: rancher/eks-operator
-    tag: v1.0.10-rc1
+    tag: v1.0.10-rc2
 
 httpProxy: ""
 httpsProxy: ""


### PR DESCRIPTION
In addition to bumping the image version, the securityContext is added to
support adding additional CAs when necessary.

Issue:
https://github.com/rancher/rancher/issues/32903