### PR TITLE
Put additional cert in /etc/rancher/ssl

### DIFF
--- a/charts/rancher-eks-operator/1.0.1000/templates/deployment.yaml
+++ b/charts/rancher-eks-operator/1.0.1000/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: {{ .Values.noProxy }}
 {{- if .Values.additionalTrustedCAs }}
         volumeMounts:
-        - mountPath: /etc/ssl/certs/ca-additional.pem
+        - mountPath: /etc/rancher/ssl/ca-additional.pem
           name: tls-ca-additional-volume
           subPath: ca-additional.pem
           readOnly: true

--- a/charts/rancher-gke-operator/1.1.200/templates/deployment.yaml
+++ b/charts/rancher-gke-operator/1.1.200/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: {{ .Values.noProxy }}
 {{- if .Values.additionalTrustedCAs }}
         volumeMounts:
-        - mountPath: /etc/ssl/certs/ca-additional.pem
+        - mountPath: /etc/rancher/ssl/ca-additional.pem
           name: tls-ca-additional-volume
           subPath: ca-additional.pem
           readOnly: true


### PR DESCRIPTION
In order for `c_rehash` to find the additional certificate, the cert
file needs to be placed in /etc/rancher/ssl.

Issue:
https://github.com/rancher/rancher/issues/32903