### PR TITLE
Standardize min/max rancher versions for new charts

### DIFF
--- a/charts/rancher-gke-operator/1.1.100/questions.yaml
+++ b/charts/rancher-gke-operator/1.1.100/questions.yaml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.5.10-patch1
+rancher_min_version: 2.5.10-alpha1

--- a/charts/rancher-logging/0.2.5/questions.yml
+++ b/charts/rancher-logging/0.2.5/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.5.10-rc1
+rancher_min_version: 2.5.10-alpha1


### PR DESCRIPTION
In 2.5.10, there are three charts that are introduced. The min
versions for these charts are inconsistent. This change fixes
these inconsistencies.