### PR TITLE
fix rancher logging on v1.22

### DIFF
--- a/charts/rancher-logging/0.4.0/.helmignore
+++ b/charts/rancher-logging/0.4.0/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/rancher-logging/0.4.0/Chart.yaml
+++ b/charts/rancher-logging/0.4.0/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+description: Rancher logging helm chart to support logging function in rancher
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+name: rancher-logging
+version: 0.3.0
+appVersion: 1.6.3
+home: https://www.fluentd.org/
+sources:
+  - https://www.fluentd.org/
+maintainers:
+  - name: Michelia
+    email: support@rancher.com
+kubeVersion: ">=1.22.0-0"

--- a/charts/rancher-logging/0.4.0/README.md
+++ b/charts/rancher-logging/0.4.0/README.md
@@ -1,0 +1,11 @@
+# Rancher Logging
+
+* Installs [Fluentd](https://www.fluentd.org/) and flexvolume log driver to collect container logs in Rancher
+
+## Introduction
+
+This chart bootstraps a [Fluentd](https://www.fluentd.org/) daemonset and a [Log-Aggregator](https://github.com/rancher/log-aggregator) flexvolume on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+It's use for sends logs to log target config in rancher.
+
+## Prerequisites
+  - Rancher 2.1+

--- a/charts/rancher-logging/0.4.0/app-readme.md
+++ b/charts/rancher-logging/0.4.0/app-readme.md
@@ -1,0 +1,8 @@
+# Rancher Logging
+
+* Installs [Fluentd](https://www.fluentd.org/) and flexvolume log driver to collect container logs in Rancher
+
+## Changelog
+
+* 0.1.5
+    * Added option `global.privileged` to enable the privileged securityContext in logging containers. This is needed when running SELinux enabled Docker on the host(s).

--- a/charts/rancher-logging/0.4.0/questions.yml
+++ b/charts/rancher-logging/0.4.0/questions.yml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.6.0-alpha1

--- a/charts/rancher-logging/0.4.0/requirements.yaml
+++ b/charts/rancher-logging/0.4.0/requirements.yaml
@@ -1,0 +1,15 @@
+dependencies:
+  - name: fluentd
+    version: 0.0.2
+    condition: fluentd.enabled
+    repository: "file://./charts/fluentd/"
+
+  - name: log-aggregator
+    version: 0.0.2
+    condition: log-aggregator.enabled
+    repository: "file://./charts/log-aggregator/"
+
+  - name: fluentd-tester
+    version: 0.0.2
+    condition: fluentd-tester.enabled
+    repository: "file://./charts/fluentd-tester/"

--- a/charts/rancher-logging/0.4.0/values.yaml
+++ b/charts/rancher-logging/0.4.0/values.yaml
@@ -1,0 +1,11 @@
+fluentd:
+  enabled: false
+fluentd-tester:
+  enabled: false
+log-aggregator:
+  enabled: false
+global:
+  systemDefaultRegistry: ""
+  podSecurityPolicy:
+    enabled: true
+  privileged: false


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/35620

# Problem
The rancher logging controller depends on finding "a latest version" of the chart existing.  If the chart does not exist we the controller will return an error even if logging is not enabled.

# Solution
Give rancher logging an empty chart in v1.22 to deploy.   This will have the same effect as uninstalling rancher logging if a cluster is upgraded to v1.22 and suppresses the errors when 