### PR TITLE
Adding required node affinity to restrict SUC to linux nodes.

### DIFF
--- a/charts/rancher-k3s-upgrader/0.3.2/templates/deployment.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.2/templates/deployment.yaml
@@ -14,6 +14,13 @@ spec:
     spec:
       affinity:
         nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "kubernetes.io/os"
+                    operator: NotIn
+                    values:
+                      - windows
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:


### PR DESCRIPTION
SUC is trying to deploy to Windows nodes and failing. Adding the required node affinity to prevent it from even trying.

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>