### PR TITLE
fix logging versions for 1.21 clusters

### DIFF
--- a/charts/rancher-logging/0.4.0/Chart.yaml
+++ b/charts/rancher-logging/0.4.0/Chart.yaml
@@ -10,4 +10,4 @@ sources:
 maintainers:
   - name: Michelia
     email: support@rancher.com
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.21.0-0"


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/35620

https://github.com/rancher/system-charts/pull/552

applying the same fix for 1.22 to 1.21