### PR TITLE
add kubeVersion to charts based on their support for k8s 1.22

### DIFF
--- a/charts/rancher-cis-benchmark/0.2.0/Chart.yaml
+++ b/charts/rancher-cis-benchmark/0.2.0/Chart.yaml
@@ -10,3 +10,4 @@ sources:
 maintainers:
   - name: Murali Paluru
     email: leodotcloud@gmail.com
+kubeVersion: '< 1.22.0-0'

--- a/charts/rancher-external-dns/v0.2.0/Chart.yaml
+++ b/charts/rancher-external-dns/v0.2.0/Chart.yaml
@@ -12,3 +12,4 @@ engine: gotpl
 maintainers:
 - name: rabadin
   email: rabadin@cisco.com
+kubeVersion: '< 1.22.0-0'

--- a/charts/rancher-istio/1.5.920/Chart.yaml
+++ b/charts/rancher-istio/1.5.920/Chart.yaml
@@ -15,3 +15,4 @@ sources:
 - http://github.com/istio/istio
 tillerVersion: '>=2.7.2-0'
 version: 1.5.920
+kubeVersion: '< 1.21.0-0'

--- a/charts/rancher-k3s-upgrader/0.3.1/Chart.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.1/Chart.yaml
@@ -7,3 +7,4 @@ sources:
   - "https://github.com/rancher/system-charts/blob/dev-v2.6/charts/rancher-k3s-upgrader"
 version: 0.3.1
 appVersion: v0.8.1
+kubeVersion: '>= 1.16.0-0'

--- a/charts/rancher-logging/0.4.0/Chart.yaml
+++ b/charts/rancher-logging/0.4.0/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Rancher logging helm chart to support logging function in rancher
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: rancher-logging
-version: 0.3.0
+version: 0.4.0
 appVersion: 1.6.3
 home: https://www.fluentd.org/
 sources:

--- a/charts/rancher-monitoring/v0.1.5/Chart.yaml
+++ b/charts/rancher-monitoring/v0.1.5/Chart.yaml
@@ -14,3 +14,4 @@ keywords:
 - operator
 - prometheus
 icon: https://coreos.com/sites/default/files/inline-images/Overview-prometheus_0.png
+kubeVersion: "< 1.21.0-0"

--- a/charts/rancher-monitoring/v0.3.1/Chart.yaml
+++ b/charts/rancher-monitoring/v0.3.1/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 - https://github.com/coreos/prometheus-operator
 version: 0.3.1
 appVersion: 0.3.1
-kubeVersion: ">=1.16.0-0"
+kubeVersion: "< 1.21.0-0"
 home: https://github.com/coreos/prometheus-operator
 keywords:
 - operator


### PR DESCRIPTION
issue https://github.com/rancher/rancher/issues/35897

- `rancher-istio 1.5.920` does not support 1.21
- `rancher-monitoring 0.1.5 & 0.3.1` does not support 1.21 ( UPDATE: the limit is set on 1.22 , see https://github.com/rancher/system-charts/pull/559)
- `rancher-cis-benchmark 0.2.0`  does not support 1.22
- `rancher-external-dns 0.2.0` does not support 1.22, see https://github.com/rancher/rancher/issues/35909
- `rancher-k3s-upgrader 0.3.1` supports 1.22
- `rancher-logging 0.4.0` is an "empty" chart, see https://github.com/rancher/system-charts/pull/552
 