### PR TITLE
change the kubeVersion for monitoring v1 chart 

### DIFF
--- a/charts/rancher-monitoring/v0.1.5/Chart.yaml
+++ b/charts/rancher-monitoring/v0.1.5/Chart.yaml
@@ -14,4 +14,4 @@ keywords:
 - operator
 - prometheus
 icon: https://coreos.com/sites/default/files/inline-images/Overview-prometheus_0.png
-kubeVersion: "< 1.21.0-0"
+kubeVersion: "< 1.22.0-0"

--- a/charts/rancher-monitoring/v0.3.1/Chart.yaml
+++ b/charts/rancher-monitoring/v0.3.1/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 - https://github.com/coreos/prometheus-operator
 version: 0.3.1
 appVersion: 0.3.1
-kubeVersion: "< 1.21.0-0"
+kubeVersion: "< 1.22.0-0"
 home: https://github.com/coreos/prometheus-operator
 keywords:
 - operator


### PR DESCRIPTION
issue https://github.com/rancher/rancher/issues/35897
Monitoring v1 can be installed on a 1.21 cluster although the grafana will not get any data from prometheus, and there is a workaround, see https://github.com/rancher/rancher/issues/33465