### PR TITLE
Set rancer_max_version to monitoring v1 chart

### DIFF
--- a/charts/rancher-monitoring/v0.3.1/questions.yml
+++ b/charts/rancher-monitoring/v0.3.1/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.6.1-alpha1
+rancher_max_version: 2.6.3


### PR DESCRIPTION
Setting rancer_max_version = 2.6.3 for v0.3.1 monitoring v1 chart