### PR TITLE
Add rancher max version to rancher k3s upgrader 0.3.1

### DIFF
--- a/charts/rancher-k3s-upgrader/0.3.1/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.3.1/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.6.0-alpha1
+rancher_max_version: 2.6.3


### PR DESCRIPTION
Add rancher max version constraint to 0.3.1 since a new version 0.3.2 was added.