### PR TITLE
Add Additional SUC Deployment label and selector

### DIFF
--- a/charts/rancher-k3s-upgrader/0.3.2/templates/deployment.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.2/templates/deployment.yaml
@@ -7,10 +7,12 @@ spec:
   selector:
     matchLabels:
       upgrade.cattle.io/controller: system-upgrade-controller
+      app: system-upgrade-controller
   template:
     metadata:
       labels:
         upgrade.cattle.io/controller: system-upgrade-controller # necessary to avoid drain
+        app: system-upgrade-controller
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36810

# Problem
The job `apply-system-agent-upgrader-on-xxx` appears within the `Deployments` section of the UI. This was due to the `upgrade.cattle.io/controller: system-upgrade-controller` label being present on both the deployment pods and the `apply-system-agent-upgrader-on-xxx` job. The deployment uses this label as a selector, which results in both the job and deployment pods being displayed in the UI. 

# Solution
Add an additional label and selector (`upgrade.cattle.io/deployment: system-upgrade-controller`) to the system-upgrade-controller deployment.yaml to ensure that no jobs are picked up and displayed in the UI. If there is a better label to use for this purpose please let me know. 

# Testing
+ Create an RKE2 cluster
+ Navigate to `WorkLoads`
+ Open the `system-upgrade-controller` deployment
+ ensure that no `apply-system-agent-upgrader-on-xxx` job appears in the UI. 