### PR TITLE
Revert additional SUC label

### DIFF
--- a/charts/rancher-k3s-upgrader/0.3.2/templates/deployment.yaml
+++ b/charts/rancher-k3s-upgrader/0.3.2/templates/deployment.yaml
@@ -7,12 +7,10 @@ spec:
   selector:
     matchLabels:
       upgrade.cattle.io/controller: system-upgrade-controller
-      app: system-upgrade-controller
   template:
     metadata:
       labels:
         upgrade.cattle.io/controller: system-upgrade-controller # necessary to avoid drain
-        app: system-upgrade-controller
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Issue(s): https://github.com/rancher/rancher/issues/38501 , https://github.com/rancher/rancher/issues/36810

The additional label added to the SUC addressed https://github.com/rancher/rancher/issues/36810, however this addition prevents the proper down-grading of a rancher server, as match label selectors are immutable. This lead to the symptoms described in https://github.com/rancher/rancher/issues/38501. This PR reverts the additional label