### PR TITLE
Hide v1 istio

### DIFF
--- a/charts/rancher-istio/1.5.920/questions.yaml
+++ b/charts/rancher-istio/1.5.920/questions.yaml
@@ -1,3 +1,4 @@
 labels:
   rancher.istio.v1.5.920: 1.5.9
 rancher_min_version: 2.6.0-alpha1
+rancher_max_version: 2.6.99


### PR DESCRIPTION
Added `rancher_max_version` constraint to hide istio chart from system-charts catalog. 

Linked issue:
https://github.com/rancher/rancher/issues/37327