### PR TITLE
Hide cis-benchmark

### DIFF
--- a/charts/rancher-cis-benchmark/0.2.0/questions.yaml
+++ b/charts/rancher-cis-benchmark/0.2.0/questions.yaml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.6.0-alpha1
+rancher_max_version: 2.6.99


### PR DESCRIPTION
Added `rancher_max_version` constraint to hide cis-benchmark chart from system-charts catalog.

Linked issue: https://github.com/rancher/rancher/issues/37322