### PR TITLE
Hide Logging

### DIFF
--- a/charts/rancher-logging/0.4.0/questions.yml
+++ b/charts/rancher-logging/0.4.0/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.6.0-alpha1
+rancher_max_version: 2.6.99


### PR DESCRIPTION
Added `rancher_max_version` constraint to hide logging chart from system-charts catalog.
Related: https://github.com/rancher/rancher/issues/37318