### PR TITLE
Conditionally enable psp

### DIFF
--- a/charts/rancher-k3s-upgrader/0.4.0/templates/psp.yaml
+++ b/charts/rancher-k3s-upgrader/0.4.0/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if .Values.global.cattle.psp.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/rancher-k3s-upgrader/0.4.0/templates/validate-psp-install.yaml
+++ b/charts/rancher-k3s-upgrader/0.4.0/templates/validate-psp-install.yaml
@@ -1,0 +1,7 @@
+#{{- if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
+#{{- if .Values.global.cattle.psp.enabled }}
+#{{- if not (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+#{{- fail "The target cluster does not have the PodSecurityPolicy API resource. Please disable PSPs in this chart before proceeding." -}}
+#{{- end }}
+#{{- end }}
+#{{- end }}

--- a/charts/rancher-k3s-upgrader/0.4.0/values.yaml
+++ b/charts/rancher-k3s-upgrader/0.4.0/values.yaml
@@ -1,6 +1,8 @@
 global:
   cattle:
     systemDefaultRegistry: ""
+    psp:
+      enabled: false
 
 systemUpgradeController:
   image:


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40384, https://github.com/rancher/rancher/issues/40385

## Problem: 
The rancher-k3s-upgrader chart will deploy PSP's if the kubernetes version running on the downstream cluster still has the capability to do so. This presents a problem when upgrading a cluster to a version which no longer has PSP support. Helm will be unable to upgrade or uninstall the upgrader due to it holding references to PSP's which can now no longer be removed.


## Solution: 
Add a new field to the rancher-k3s-upgrader chart, `psp: enabled` and set its default value to `false`. This value will be used within Rancher to determine if PSP's are enabled or disabled on any version of Kubernetes, and will be used to block upgrades to 1.25+ until a new version of the upgrader is deployed which has psp's disabled. 


I've added a new version, `0.4.1`, though I don't believe `0.4.0` has been released yet. If it's better that I modify that version let me know. 