### PR TITLE
Remove Helm 3 function from PSP 0.4.0 to ensure Helm 2 compatibility

### DIFF
--- a/charts/rancher-k3s-upgrader/0.4.0/templates/validate-psp-install.yaml
+++ b/charts/rancher-k3s-upgrader/0.4.0/templates/validate-psp-install.yaml
@@ -1,7 +1,5 @@
-#{{- if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
 #{{- if .Values.global.cattle.psp.enabled }}
 #{{- if not (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 #{{- fail "The target cluster does not have the PodSecurityPolicy API resource. Please disable PSPs in this chart before proceeding." -}}
-#{{- end }}
 #{{- end }}
 #{{- end }}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40385


## Problem:

The prior PR for updating the rancher-k3s-upgrader chart for `v0.4.0` added a new file `validate-psp-install.yaml`. This file is responsible for ensuring that Pod Security Policies are still supported for a given version of Kubernetes before deploying the Pod Security Policy resource. It also includes an RBAC check when doing so. Unfortunately, that RBAC check will fail when running this chart using helm 2, as the `lookup` function is not available in that helm release. 

The controller used in Rancher to deploy the System Upgrade Controller to imported RKE2/K3s clusters has been using Helm 2 for some time now - from what I can tell there is not a released version of Rancher where this controller uses Helm 3. 

This presents a problem, as this controller automatically updates the System Upgrade Controller to the newest available version. This would result in an inability to deploy the chart for all prior Rancher versions, preventing upgrades of imported clusters from working at all for everyone using a Rancher version sub 2.7.2. 

## Solution:

This PR removes the RBAC check so that we are compatible with Helm 2. This allows all Rancher versions to consume newer versions of the System Upgrade Controller.