### PR TITLE
More rancher-k3s-upgrader chart changes based off of recent testing

### DIFF
--- a/charts/rancher-k3s-upgrader/0.4.0/templates/validate-psp-install.yaml
+++ b/charts/rancher-k3s-upgrader/0.4.0/templates/validate-psp-install.yaml
@@ -1,5 +1,0 @@
-#{{- if .Values.global.cattle.psp.enabled }}
-#{{- if not (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
-#{{- fail "The target cluster does not have the PodSecurityPolicy API resource. Please disable PSPs in this chart before proceeding." -}}
-#{{- end }}
-#{{- end }}

--- a/charts/rancher-k3s-upgrader/0.4.0/values.yaml
+++ b/charts/rancher-k3s-upgrader/0.4.0/values.yaml
@@ -2,7 +2,7 @@ global:
   cattle:
     systemDefaultRegistry: ""
     psp:
-      enabled: false
+      enabled: true
 
 systemUpgradeController:
   image:


### PR DESCRIPTION
## Issues: https://github.com/rancher/rancher/issues/40384 https://github.com/rancher/rancher/issues/40385


## Problem: 
This is the third (and hopefully final) PR to update the rancher-k3s-upgrader chart. This PR is being raised after testing revealed that additional changes are required for the above linked issues. The following problems were found in the context of imported RKE2/K3s clusters:

1. The controller which manages the deployment and upgrade of the system-upgrade-controller onto downstream imported RKE2/K3s clusters (`pkg/controllers/management/k3sbased_upgrade_handler`) is creating the SUC app using Helm 2, and not Helm 3. This means all previously released versions of Rancher are deploying the SUC onto downstream imported clusters using Helm 2. Helm 2 does not provide the `lookup` function that was previously added to the `validate-psp-install.yaml` file. 

2. When generating helm templates for imported RKE2/K3s clusters, the helm template command is run on the local cluster only (`pkg/controllers/managementuserlegacy/helm/common.go:183`). This prevented the API capabilities check from occurring properly, as we did not have information on the downstream clusters capabilities. From what I could see in my testing, this issue did not occur for Rancher provisioned RKE2/K3s clusters, as the helm operation is done within a pod on the downstream cluster.

3. Prior PR's defaulted the `psp: enabled` value to `false`, however this also presents a problem for users of Rancher sub `v2.7.2`. The controller which manages the SUC on imported clusters continuously attempts to use the latest version of the chart, and by setting the value to `false` we will inadvertently disable PSP's for all imported clusters regardless of the Rancher version.


## Solution:

+ Remove the `validate-psp-install.yaml` file entirely, as the checks it provides can not be satisfied in all scenarios that the System Upgrade Controller is used within Rancher. At this point the only check the file was providing was the API compatibility check, which cannot be handled as described above.

+ Change the default value of `psp: enabled` to true to ensure that older versions of Rancher which do intend to deploy PSP resources continue to do so. After 2.7.2 the controllers which deploy the SUC will be responsible for explicitly disabling PSPs.


Sorry for the barrage of recent changes to this chart, each iteration can't be easily tested until its merged and bumped in the charts repo.
