### PR TITLE
add rancher-k3s-upgrader 0.5.0

### DIFF
--- a/charts/rancher-k3s-upgrader/0.5.0/Chart.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: rancher-k3s-upgrader
+description: Enables a k3s or rke2 cluster to update itself by reacting to Plan CRs.
+  Users do not need to manually upgrade this app. It will be automatically upgraded to the latest version when upgrading a cluster.
+home: https://github.com/rancher/system-charts/blob/dev-v2.7/charts/rancher-k3s-upgrader
+sources:
+  - "https://github.com/rancher/system-charts/blob/dev-v2.7/charts/rancher-k3s-upgrader"
+version: 0.4.0
+appVersion: v0.10.0
+kubeVersion: '>= 1.16.0-0'

--- a/charts/rancher-k3s-upgrader/0.5.0/Chart.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/Chart.yaml
@@ -5,6 +5,6 @@ description: Enables a k3s or rke2 cluster to update itself by reacting to Plan 
 home: https://github.com/rancher/system-charts/blob/dev-v2.7/charts/rancher-k3s-upgrader
 sources:
   - "https://github.com/rancher/system-charts/blob/dev-v2.7/charts/rancher-k3s-upgrader"
-version: 0.4.0
-appVersion: v0.10.0
-kubeVersion: '>= 1.16.0-0'
+version: 0.5.0
+appVersion: v0.11.0
+kubeVersion: '>= 1.23.0-0'

--- a/charts/rancher-k3s-upgrader/0.5.0/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.5.0/questions.yml
@@ -1,0 +1,1 @@
+rancher_min_version: 2.6.0-alpha1

--- a/charts/rancher-k3s-upgrader/0.5.0/questions.yml
+++ b/charts/rancher-k3s-upgrader/0.5.0/questions.yml
@@ -1,1 +1,1 @@
-rancher_min_version: 2.6.0-alpha1
+rancher_min_version: 2.7.0-alpha1

--- a/charts/rancher-k3s-upgrader/0.5.0/templates/NOTES.txt
+++ b/charts/rancher-k3s-upgrader/0.5.0/templates/NOTES.txt
@@ -1,0 +1,4 @@
+You have deployed the Rancher K3s Upgrader
+Version: {{ .Chart.AppVersion }}
+Description: This controller enables a k3s or rke2 cluster to update itself by reacting to Plan CRs.
+    Users do not need to manually upgrade this app. It will be automatically upgraded to the latest version when upgrading a cluster.

--- a/charts/rancher-k3s-upgrader/0.5.0/templates/_helpers.tpl
+++ b/charts/rancher-k3s-upgrader/0.5.0/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-k3s-upgrader/0.5.0/templates/clusterrolebinding.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  system-upgrade-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: system-upgrade-controller
+    namespace: cattle-system

--- a/charts/rancher-k3s-upgrader/0.5.0/templates/configmap.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: system-upgrade-controller-config
+  namespace: cattle-system
+data:
+  SYSTEM_UPGRADE_CONTROLLER_DEBUG: {{ .Values.systemUpgradeControllerDebug | default "false" | quote }}
+  SYSTEM_UPGRADE_CONTROLLER_THREADS: {{ .Values.systemUpgradeControllerThreads | default "2" | quote }}
+  SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: {{ .Values.systemUpgradeJobActiveDeadlineSeconds | default "900" | quote }}
+  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: {{ .Values.systemUpgradeJobBackoffLimit | default "99" | quote }}
+  SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: {{ .Values.systemUpgradeJobImagePullPolicy | default "IfNotPresent" | quote }}
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: {{ template "system_default_registry" . }}{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+  SYSTEM_UPGRADE_JOB_PRIVILEGED: {{ .Values.systemUpgradeJobPrivileged | default "true" | quote }}
+  SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: {{ .Values.systemUpgradeJobTTLSecondsAfterFinish | default "900" | quote }}
+  SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL: {{ .Values.systemUpgradePlanRollingInterval | default "15m" | quote }}
+

--- a/charts/rancher-k3s-upgrader/0.5.0/templates/deployment.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-upgrade-controller
+  namespace: cattle-system
+spec:
+  selector:
+    matchLabels:
+      upgrade.cattle.io/controller: system-upgrade-controller
+  template:
+    metadata:
+      labels:
+        upgrade.cattle.io/controller: system-upgrade-controller # necessary to avoid drain
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "kubernetes.io/os"
+                    operator: NotIn
+                    values:
+                      - windows
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: In
+                  values:
+                    - "true"
+            weight: 100
+          - preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: In
+                  values:
+                    - "true"
+            weight: 100
+      tolerations:
+        - operator: Exists
+      serviceAccountName: system-upgrade-controller
+      containers:
+        - name: system-upgrade-controller
+          image: {{ template "system_default_registry" . }}{{ .Values.systemUpgradeController.image.repository }}:{{ .Values.systemUpgradeController.image.tag }}
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: system-upgrade-controller-config
+          env:
+            - name: SYSTEM_UPGRADE_CONTROLLER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['upgrade.cattle.io/controller']
+            - name: SYSTEM_UPGRADE_CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: etc-ssl
+              mountPath: /etc/ssl
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: etc-ssl
+          hostPath:
+            path: /etc/ssl
+            type: Directory
+        - name: tmp
+          emptyDir: {}

--- a/charts/rancher-k3s-upgrader/0.5.0/templates/namespace.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cattle-system
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/charts/rancher-k3s-upgrader/0.5.0/templates/psp.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/templates/psp.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.global.cattle.psp.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: system-upgrade-controller
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - CAP_SYS_BOOT
+  hostNetwork: true
+  hostPID: true
+  hostIPC: true
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller-psp
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - system-upgrade-controller
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  system-upgrade-controller-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller-psp
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:serviceaccounts:cattle-system
+{{- end }}

--- a/charts/rancher-k3s-upgrader/0.5.0/templates/serviceaccount.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: system-upgrade-controller
+  namespace: cattle-system

--- a/charts/rancher-k3s-upgrader/0.5.0/values.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/values.yaml
@@ -1,0 +1,15 @@
+global:
+  cattle:
+    systemDefaultRegistry: ""
+    psp:
+      enabled: true
+
+systemUpgradeController:
+  image:
+    repository: rancher/system-upgrade-controller
+    tag: v0.10.0
+
+kubectl:
+  image:
+    repository: rancher/kubectl
+    tag: v1.23.3

--- a/charts/rancher-k3s-upgrader/0.5.0/values.yaml
+++ b/charts/rancher-k3s-upgrader/0.5.0/values.yaml
@@ -7,7 +7,7 @@ global:
 systemUpgradeController:
   image:
     repository: rancher/system-upgrade-controller
-    tag: v0.10.0
+    tag: v0.11.0
 
 kubectl:
   image:


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/41511

This PR adds a new version, 0.5.0, for the chart  rancher-k3s-upgrader.
Noticeable change between 0.5.0 and 0.4.0 are:
- bump the tag of the image rancher/system-upgrade-controller to v0.11.0
- bump kubeVersion to 1.23 which is the minimum k8s version that Rancher v2.7.0 supports
- fix the value of rancher_min_version.  This did not cause any issues because v0.4.0 is available only in rancher 2.7.x 


### Test 

The chart is tested local on a k3s 1.26.4 cluster. 

```
> k version
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"27", GitVersion:"v1.27.1", GitCommit:"4c9411232e10168d7b050c49a1b59f6df9d7ea4b", GitTreeState:"clean", BuildDate:"2023-04-14T13:14:41Z", GoVersion:"go1.20.3", Compiler:"gc", Platform:"darwin/arm64"}
Kustomize Version: v5.0.1
Server Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.4+k3s1", GitCommit:"8d0255af07e95b841952563253d27b0d10bd72f0", GitTreeState:"clean", BuildDate:"2023-04-20T00:33:13Z", GoVersion:"go1.19.8", Compiler:"gc", Platform:"linux/arm64"}
```

The helm chart is installed successfully with setting `global.cattle.psp.enabeld=false`
```
>  helm install rancher-k3s-upgrade --set global.cattle.psp.enabeld=false  .
NAME: rancher-k3s-upgrade
LAST DEPLOYED: Thu May 11 17:38:06 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
You have deployed the Rancher K3s Upgrader
Version: v0.11.0
Description: This controller enables a k3s or rke2 cluster to update itself by reacting to Plan CRs.
    Users do not need to manually upgrade this app. It will be automatically upgraded to the latest version when upgrading a cluster.
```

