### PR TITLE
fix: Allow rancher-monitoring to be installed on k8s clusters above v2

### DIFF
--- a/charts/rancher-monitoring/v0.3.2/Chart.yaml
+++ b/charts/rancher-monitoring/v0.3.2/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 - https://github.com/coreos/prometheus-operator
 version: 0.3.2
 appVersion: 0.3.2
-kubeVersion: "< 1.22.0-0"
+kubeVersion: "< 1.26.0-0"
 home: https://github.com/coreos/prometheus-operator
 keywords:
 - operator


### PR DESCRIPTION
When using rancher terraform provider with `enable_cluster_monitoring = true` to import clusters 1.22 and above, clusters are imported with an error: `Template system-library-rancher-monitoring incompatible with rancher version or cluster's [*****] kubernetes version`; example of a resource block is below:
```
resource "rancher2_cluster" "cluster" {
  name                      = "cluster"
  enable_cluster_monitoring = true
}
```